### PR TITLE
[WIP] Implement Payroll Kit

### DIFF
--- a/kits/bare/.gitignore
+++ b/kits/bare/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/kits/bare/arapp.json
+++ b/kits/bare/arapp.json
@@ -1,0 +1,6 @@
+{
+  "appName": "bare-kit.aragonpm.eth",
+  "version": "1.0.0",
+  "roles": [],
+  "path": "contracts/BareKit.sol"
+}

--- a/kits/bare/contracts/BareKit.sol
+++ b/kits/bare/contracts/BareKit.sol
@@ -1,0 +1,42 @@
+pragma solidity 0.4.18;
+
+import "@aragon/os/contracts/kernel/Kernel.sol";
+import "@aragon/os/contracts/acl/ACL.sol";
+
+import "./KitBase.sol";
+
+contract BareKit is KitBase {
+    event DeployInstance(address dao);
+    event InstalledApp(address appProxy, bytes32 appId);
+
+    function BareKit(DAOFactory _fac, ENS _ens) KitBase(_fac, _ens) {}
+
+    function newInstance(bytes32 appId, bytes32[] roles, address authorizedAddress, bytes initialize) returns (Kernel dao, ERCProxy proxy) {
+        address root = msg.sender;
+        dao = fac.newDAO(this);
+        ACL acl = ACL(dao.acl());
+
+        acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
+
+        // If there is no appId, an empty DAO will be created
+        if (appId != bytes32(0)) {
+            proxy = dao.newAppInstance(appId, latestVersionAppBase(appId)); 
+
+            for (uint256 i = 0; i < roles.length; i++) {
+                acl.createPermission(authorizedAddress, proxy, roles[i], root);
+            }        
+
+            InstalledApp(proxy, appId);
+        }
+
+        acl.grantPermission(root, dao, dao.APP_MANAGER_ROLE());
+        acl.revokePermission(this, dao, dao.APP_MANAGER_ROLE());
+        acl.setPermissionManager(root, dao, dao.APP_MANAGER_ROLE());
+
+        acl.grantPermission(root, acl, acl.CREATE_PERMISSIONS_ROLE());
+        acl.revokePermission(this, acl, acl.CREATE_PERMISSIONS_ROLE());
+        acl.setPermissionManager(root, acl, acl.CREATE_PERMISSIONS_ROLE());
+
+        DeployInstance(dao);
+    }
+}

--- a/kits/bare/contracts/Imports.sol
+++ b/kits/bare/contracts/Imports.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.18;
+
+// HACK to workaround truffle artifact loading on dependencies
+
+import "@aragon/os/contracts/factory/ENSFactory.sol";
+import "@aragon/os/contracts/factory/APMRegistryFactory.sol";
+import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
+
+contract Imports {}

--- a/kits/bare/contracts/KitBase.sol
+++ b/kits/bare/contracts/KitBase.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.4.18;
+
+import "@aragon/os/contracts/factory/DAOFactory.sol";
+import "@aragon/os/contracts/apm/Repo.sol";
+import "@aragon/os/contracts/lib/ens/ENS.sol";
+import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
+
+contract KitBase {
+	ENS public ens;
+    DAOFactory public fac;
+
+    function KitBase(DAOFactory _fac, ENS _ens) {
+    	fac = _fac;
+    	ens = _ens;
+    }
+
+	function latestVersionAppBase(bytes32 appId) public view returns (address base) {
+        Repo repo = Repo(PublicResolver(ens.resolver(appId)).addr(appId));
+        (,base,) = repo.getLatest();
+
+        return base;
+    }
+}

--- a/kits/bare/contracts/KitBase.sol
+++ b/kits/bare/contracts/KitBase.sol
@@ -2,10 +2,12 @@ pragma solidity 0.4.18;
 
 import "@aragon/os/contracts/factory/DAOFactory.sol";
 import "@aragon/os/contracts/apm/Repo.sol";
+import "@aragon/os/contracts/apm/APMNamehash.sol";
 import "@aragon/os/contracts/lib/ens/ENS.sol";
 import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 
-contract KitBase {
+
+contract KitBase is APMNamehash {
     ENS public ens;
     DAOFactory public fac;
 

--- a/kits/bare/contracts/KitBase.sol
+++ b/kits/bare/contracts/KitBase.sol
@@ -9,6 +9,9 @@ contract KitBase {
 	ENS public ens;
     DAOFactory public fac;
 
+    event DeployInstance(address dao);
+    event InstalledApp(address appProxy, bytes32 appId);
+
     function KitBase(DAOFactory _fac, ENS _ens) {
     	fac = _fac;
     	ens = _ens;

--- a/kits/bare/contracts/KitBase.sol
+++ b/kits/bare/contracts/KitBase.sol
@@ -6,18 +6,18 @@ import "@aragon/os/contracts/lib/ens/ENS.sol";
 import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 
 contract KitBase {
-	ENS public ens;
+    ENS public ens;
     DAOFactory public fac;
 
     event DeployInstance(address dao);
     event InstalledApp(address appProxy, bytes32 appId);
 
     function KitBase(DAOFactory _fac, ENS _ens) {
-    	fac = _fac;
-    	ens = _ens;
+        fac = _fac;
+        ens = _ens;
     }
 
-	function latestVersionAppBase(bytes32 appId) public view returns (address base) {
+    function latestVersionAppBase(bytes32 appId) public view returns (address base) {
         Repo repo = Repo(PublicResolver(ens.resolver(appId)).addr(appId));
         (,base,) = repo.getLatest();
 

--- a/kits/bare/manifest.json
+++ b/kits/bare/manifest.json
@@ -1,0 +1,3 @@
+{
+	"name": "Bare Kit"
+}

--- a/kits/bare/package.json
+++ b/kits/bare/package.json
@@ -9,6 +9,6 @@
     "deploy:fac:rpc": "aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
   },
   "dependencies": {
-    "@aragon/os": "^3.1.7"
+    "@aragon/os": "3.1.8"
   }
 }

--- a/kits/bare/package.json
+++ b/kits/bare/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@aragon/kits-bare",
+  "version": "1.0.0",
+  "description": "Generic kit for deploying and setting up a DAO with one app",
+  "author": "Aragon One AG <contact@aragon.one>",
+  "license": "GPL-3.0",
+  "scripts": {
+    "publish:rpc": "apm publish BareKit --publish-dir ../lol --network rpc --init $(npm run deploy:fac:rpc | tail -n 1) @ARAGON_ENS",
+    "deploy:fac:rpc": "aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
+  },
+  "dependencies": {
+    "@aragon/os": "^3.1.7"
+  }
+}

--- a/kits/bare/package.json
+++ b/kits/bare/package.json
@@ -5,7 +5,7 @@
   "author": "Aragon One AG <contact@aragon.one>",
   "license": "GPL-3.0",
   "scripts": {
-    "publish:rpc": "apm publish BareKit --publish-dir ../lol --network rpc --init $(npm run deploy:fac:rpc | tail -n 1) @ARAGON_ENS",
+    "publish:rpc": "apm publish BareKit --network rpc --init $(npm run deploy:fac:rpc | tail -n 1) @ARAGON_ENS",
     "deploy:fac:rpc": "aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
   },
   "dependencies": {

--- a/kits/bare/package.json
+++ b/kits/bare/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "publish:rpc": "apm publish BareKit --network rpc --init $(npm run deploy:fac:rpc | tail -n 1) @ARAGON_ENS",
-    "deploy:fac:rpc": "aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
+    "deploy:fac:rpc": "aragon contracts compile --all && aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
   },
   "dependencies": {
     "@aragon/os": "3.1.8"

--- a/kits/bare/package.json
+++ b/kits/bare/package.json
@@ -9,6 +9,6 @@
     "deploy:fac:rpc": "aragon contracts compile --all && aragon contracts exec --network rpc scripts/deploy-dao-factory.js"
   },
   "dependencies": {
-    "@aragon/os": "3.1.8"
+    "@aragon/os": "3.1.9"
   }
 }

--- a/kits/bare/scripts/deploy-dao-factory.js
+++ b/kits/bare/scripts/deploy-dao-factory.js
@@ -1,0 +1,6 @@
+const daoFactoryMigration = require('@aragon/os/migrations/3_factory')
+
+module.exports = async callback => {
+	const { daoFact } = await daoFactoryMigration(null, null, null, artifacts)
+	console.log(daoFact.address)
+}

--- a/kits/bare/truffle.js
+++ b/kits/bare/truffle.js
@@ -1,0 +1,6 @@
+let x = require("@aragon/os/truffle-config")
+
+x.networks.rinkeby.gasPrice = 25000000001
+x.networks.rinkeby.gas = 7e6
+
+module.exports = x

--- a/kits/payroll/contracts/Imports.sol
+++ b/kits/payroll/contracts/Imports.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.18;
+
+// HACK to workaround truffle artifact loading on dependencies
+
+import "@aragon/os/contracts/factory/ENSFactory.sol";
+import "@aragon/os/contracts/factory/APMRegistryFactory.sol";
+import "@aragon/os/contracts/factory/EVMScriptRegistryFactory.sol";
+
+contract Imports {}

--- a/kits/payroll/contracts/PayrollKit.sol
+++ b/kits/payroll/contracts/PayrollKit.sol
@@ -1,0 +1,94 @@
+pragma solidity 0.4.18;
+
+import "@aragon/os/contracts/kernel/Kernel.sol";
+import "@aragon/os/contracts/acl/ACL.sol";
+import "@aragon/os/contracts/apm/APMNamehash.sol";
+
+import "@aragon/future-apps-payroll/contracts/Payroll.sol";
+import "@aragon/apps-finance/contracts/Finance.sol";
+import "@aragon/apps-vault/contracts/Vault.sol";
+
+import "@aragon/kits-bare/contracts/KitBase.sol";
+
+
+contract PayrollKit is KitBase {
+    function PayrollKit(DAOFactory _fac, ENS _ens) KitBase(_fac, _ens) {}
+
+    function newInstance(
+        address employer,
+        address root,
+        uint64 financePeriodDuration,
+        address denominationToken,
+        IFeed priceFeed, 
+        uint64 rateExpiryTime
+    ) returns (Kernel dao, Payroll payroll) {
+        dao = fac.newDAO(this);
+        ACL acl = ACL(dao.acl());
+
+        acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
+
+        Vault vault;
+        Finance finance;
+        (vault, finance, payroll) = deployApps(dao);
+ 
+        finance.initialize(vault, financePeriodDuration);
+        payroll.initialize(finance, denominationToken, priceFeed, rateExpiryTime);
+
+        // Payroll permissions
+        acl.createPermission(employer, payroll, payroll.ADD_EMPLOYEE_ROLE(), root);
+        acl.createPermission(employer, payroll, payroll.REMOVE_EMPLOYEE_ROLE(), root);
+        acl.createPermission(employer, payroll, payroll.ALLOWED_TOKENS_MANAGER_ROLE(), root);
+        acl.createPermission(root, payroll, payroll.CHANGE_PRICE_FEED_ROLE(), root);
+        acl.createPermission(root, payroll, payroll.MODIFY_RATE_EXPIRY_ROLE(), root);
+
+        // Finance permissions
+        acl.createPermission(payroll, finance, finance.CREATE_PAYMENTS_ROLE(), root);
+
+        // Vault permissions
+        bytes32 vaultTransferRole = vault.TRANSFER_ROLE();
+        acl.createPermission(finance, vault, vaultTransferRole, this); // manager is this to allow 2 grants
+        acl.grantPermission(root, vault, vaultTransferRole);
+        acl.setPermissionManager(root, vault, vaultTransferRole); // set root as the final manager for the role
+
+        cleanupDAOPermissions(dao, acl, root);
+
+        DeployInstance(dao);
+    }
+
+    function deployApps(Kernel dao) internal returns (Vault, Finance, Payroll) {
+        bytes32 vaultAppId = apmNamehash("vault");
+        bytes32 financeAppId = apmNamehash("finance");
+        bytes32 payrollAppId = apmNamehash("payroll");
+
+        Vault vault = Vault(dao.newAppInstance(vaultAppId, latestVersionAppBase(vaultAppId)));
+        Finance finance = Finance(dao.newAppInstance(financeAppId, latestVersionAppBase(financeAppId)));
+        Payroll payroll = Payroll(dao.newAppInstance(payrollAppId, latestVersionAppBase(payrollAppId)));
+
+        InstalledApp(vault, vaultAppId);
+        InstalledApp(finance, financeAppId);
+        InstalledApp(payroll, payrollAppId);
+
+        return (vault, finance, payroll);
+    }
+
+    function cleanupDAOPermissions(Kernel dao, ACL acl, address root) internal {
+        bytes32 daoAppManagerRole = dao.APP_MANAGER_ROLE();
+        // Kernel permission clean up
+        acl.grantPermission(root, dao, daoAppManagerRole);
+        acl.revokePermission(this, dao, daoAppManagerRole);
+        acl.setPermissionManager(root, dao, daoAppManagerRole);
+
+        // ACL permission clean up
+        bytes32 aclCreatePermissionsRole = acl.CREATE_PERMISSIONS_ROLE();
+        acl.grantPermission(root, acl, aclCreatePermissionsRole);
+        acl.revokePermission(this, acl, aclCreatePermissionsRole);
+        acl.setPermissionManager(root, acl, aclCreatePermissionsRole);
+    }
+
+    function latestVersionAppBase(bytes32 appId) public view returns (address base) {
+        Repo repo = Repo(PublicResolver(ens.resolver(appId)).addr(appId));
+        (,base,) = repo.getLatest();
+
+        return base;
+    }
+}

--- a/kits/payroll/contracts/misc/Migrations.sol
+++ b/kits/payroll/contracts/misc/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.17;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function Migrations() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/kits/payroll/migrations/1_initial_migration.js
+++ b/kits/payroll/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/kits/payroll/package.json
+++ b/kits/payroll/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@aragon/kits-payroll",
+  "version": "1.0.0",
+  "description": "Kit for setting up a DAO to do Payroll",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "migrate": "truffle migrate --network rpc --reset"
+  },
+  "author": "Aragon Institution MTU <contact@aragon.one>",
+  "license": "GPL-3.0",
+  "devDependencies": {
+    "eth-ens-namehash": "^2.0.8",
+    "truffle": "4.0.5",
+    "truffle-hdwallet-provider": "0.0.3"
+  },
+  "dependencies": {
+    "@aragon/apps-finance": "^1.0.0",
+    "@aragon/apps-vault": "^2.0.1",
+    "@aragon/future-apps-payroll": "^0.0.1",
+    "@aragon/kits-bare": "^1.0.0",
+    "@aragon/ppf-contracts": "^1.0.2",
+    "@aragon/os": "^3.1.9"
+  }
+}

--- a/kits/payroll/truffle.js
+++ b/kits/payroll/truffle.js
@@ -1,0 +1,6 @@
+let x = require("@aragon/os/truffle-config")
+
+x.networks.rinkeby.gasPrice = 25000000001
+x.networks.rinkeby.gas = 7e6
+
+module.exports = x


### PR DESCRIPTION
Builds on #8

Implements a PayrollKit with permissions ready for a production environment. It grants all admin permissions to a `root` account to be able to upgrade or rescue the funds in case of an incident.  

I think we should build a PayrollDemoKit inside this package too so it can be easy to deploy locally for testing purposes.

Here is a diagram of the current permissions:
<img width="854" alt="2018-06-15 at 7 41 49 pm" src="https://user-images.githubusercontent.com/447328/41481998-663e9f6e-70d4-11e8-8a72-730815da506d.png">