### PR TITLE
Restructure Company with Board template's initialization

### DIFF
--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -83,7 +83,7 @@ contract BaseTemplate is APMNamehash, IsContract {
 
     /* ACL */
 
-    function _createPermissions(ACL _acl, address[] _grantees, address _app, bytes32 _permission, address _manager) internal {
+    function _createPermissions(ACL _acl, address[] memory _grantees, address _app, bytes32 _permission, address _manager) internal {
         _acl.createPermission(_grantees[0], _app, _permission, address(this));
         for (uint256 i = 1; i < _grantees.length; i++) {
             _acl.grantPermission(_grantees[i], _app, _permission);
@@ -151,7 +151,7 @@ contract BaseTemplate is APMNamehash, IsContract {
 
     /* VOTING */
 
-    function _installVotingApp(Kernel _dao, MiniMeToken _token, uint64[3] _votingSettings) internal returns (Voting) {
+    function _installVotingApp(Kernel _dao, MiniMeToken _token, uint64[3] memory _votingSettings) internal returns (Voting) {
         return _installVotingApp(_dao, _token, _votingSettings[0], _votingSettings[1], _votingSettings[2]);
     }
 
@@ -208,7 +208,7 @@ contract BaseTemplate is APMNamehash, IsContract {
         _acl.createPermission(_settingsManager, _payroll, _payroll.MANAGE_ALLOWED_TOKENS_ROLE(), _permissionsManager);
     }
 
-    function _unwrapPayrollSettings(uint256[4] _payrollSettings) internal pure returns (address denominationToken, IFeed priceFeed, uint64 rateExpiryTime, address employeeManager) {
+    function _unwrapPayrollSettings(uint256[4] memory _payrollSettings) internal pure returns (address denominationToken, IFeed priceFeed, uint64 rateExpiryTime, address employeeManager) {
         denominationToken = _toAddress(_payrollSettings[0]);
         priceFeed = IFeed(_toAddress(_payrollSettings[1]));
         rateExpiryTime = _payrollSettings[2].toUint64();
@@ -242,7 +242,7 @@ contract BaseTemplate is APMNamehash, IsContract {
         _acl.createPermission(_grantee, _tokenManager, _tokenManager.BURN_ROLE(), _manager);
     }
 
-    function _mintTokens(ACL _acl, TokenManager _tokenManager, address[] _holders, uint256[] _stakes) internal {
+    function _mintTokens(ACL _acl, TokenManager _tokenManager, address[] memory _holders, uint256[] memory _stakes) internal {
         _createPermissionForTemplate(_acl, _tokenManager, _tokenManager.MINT_ROLE());
         for (uint256 i = 0; i < _holders.length; i++) {
             _tokenManager.mint(_holders[i], _stakes[i]);
@@ -250,7 +250,7 @@ contract BaseTemplate is APMNamehash, IsContract {
         _removePermissionFromTemplate(_acl, _tokenManager, _tokenManager.MINT_ROLE());
     }
 
-    function _mintTokens(ACL _acl, TokenManager _tokenManager, address[] _holders, uint256 _stake) internal {
+    function _mintTokens(ACL _acl, TokenManager _tokenManager, address[] memory _holders, uint256 _stake) internal {
         _createPermissionForTemplate(_acl, _tokenManager, _tokenManager.MINT_ROLE());
         for (uint256 i = 0; i < _holders.length; i++) {
             _tokenManager.mint(_holders[i], _stake);
@@ -278,7 +278,7 @@ contract BaseTemplate is APMNamehash, IsContract {
         return _installNonDefaultApp(_dao, _appId, new bytes(0));
     }
 
-    function _installNonDefaultApp(Kernel _dao, bytes32 _appId, bytes _initializeData) internal returns (address) {
+    function _installNonDefaultApp(Kernel _dao, bytes32 _appId, bytes memory _initializeData) internal returns (address) {
         return _installApp(_dao, _appId, _initializeData, false);
     }
 
@@ -286,11 +286,11 @@ contract BaseTemplate is APMNamehash, IsContract {
         return _installDefaultApp(_dao, _appId, new bytes(0));
     }
 
-    function _installDefaultApp(Kernel _dao, bytes32 _appId, bytes _initializeData) internal returns (address) {
+    function _installDefaultApp(Kernel _dao, bytes32 _appId, bytes memory _initializeData) internal returns (address) {
         return _installApp(_dao, _appId, _initializeData, true);
     }
 
-    function _installApp(Kernel _dao, bytes32 _appId, bytes _initializeData, bool _setDefault) internal returns (address) {
+    function _installApp(Kernel _dao, bytes32 _appId, bytes memory _initializeData, bool _setDefault) internal returns (address) {
         address latestBaseAppAddress = _latestVersionAppBase(_appId);
         address instance = address(_dao.newAppInstance(_appId, latestBaseAppAddress, _initializeData, _setDefault));
         emit InstalledApp(instance, _appId);
@@ -304,7 +304,7 @@ contract BaseTemplate is APMNamehash, IsContract {
 
     /* TOKEN */
 
-    function _createToken(string _name, string _symbol, uint8 _decimals) internal returns (MiniMeToken) {
+    function _createToken(string memory _name, string memory _symbol, uint8 _decimals) internal returns (MiniMeToken) {
         require(address(miniMeFactory) != address(0), ERROR_MINIME_FACTORY_NOT_PROVIDED);
         MiniMeToken token = miniMeFactory.createCloneToken(MiniMeToken(address(0)), 0, _name, _decimals, _symbol, true);
         emit DeployToken(address(token));
@@ -317,7 +317,7 @@ contract BaseTemplate is APMNamehash, IsContract {
 
     /* IDS */
 
-    function _registerID(string _name, address _owner) internal {
+    function _registerID(string memory _name, address _owner) internal {
         require(address(aragonID) != address(0), ERROR_ARAGON_ID_NOT_PROVIDED);
         aragonID.register(keccak256(abi.encodePacked(_name)), _owner);
     }

--- a/templates/bare/contracts/BareTemplate.sol
+++ b/templates/bare/contracts/BareTemplate.sol
@@ -16,7 +16,7 @@ contract BareTemplate is BaseTemplate {
         newInstance(bytes32(0), new bytes32[](0), address(0), new bytes(0));
     }
 
-    function newInstance(bytes32 _appId, bytes32[] _roles, address _authorizedAddress, bytes _initializeCallData) public {
+    function newInstance(bytes32 _appId, bytes32[] memory _roles, address _authorizedAddress, bytes memory _initializeCallData) public {
         address root = msg.sender;
         (Kernel dao, ACL acl) = _createDAO();
 

--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -2,29 +2,37 @@
 
 ## Usage
 
-Create new tokens and initialize DAO for the company-board entity:
+Prepare an incomplete company-board entity:
 
 ```
-template.prepareInstance(shareTokenName, shareTokenSymbol)
+template.prepareInstance(shareTokenName, shareTokenSymbol, shareVotingSettings, boardVotingSettings)
 ```
 
 - `shareTokenName`: Name for the token used by share holders in the organization
 - `shareTokenSymbol`: Symbol for the token used by share holders in the organization
+- `shareVotingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the share voting app of the organization
+- `boardVotingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the board voting app of the organization
 
-Setup company-board DAO:
+Finalize company-board entity:
 
 ```
-template.setupInstance(name, boardHolders, shareHolders, shareStakes, boardVotingSettings, shareVotingSettings, financePeriod, useAgentAsVault)
+template.finalizeInstance(name, shareHolders, shareStakes, boardMembers, financePeriod, useAgentAsVault)
 ```
 
 - `name`: Name for org, will assign `[name].aragonid.eth`
-- `boardMembers`: Array of board member addresses (1 token will be minted for each board member)
 - `shareHolders`: Array of share holder addresses
 - `shareStakes`: Array of token stakes for share holders (token has 18 decimals, multiply token amount `* 10^18`)
-- `boardVotingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the board voting app of the organization
-- `shareVotingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the share voting app of the organization
+- `boardMembers`: Array of board member addresses (1 token will be minted for each board member)
 - `financePeriod`: Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
 - `useAgentAsVault`: Use an Agent app as a more advanced form of Vault app
+
+Alternatively, create a new company entity with a Payroll app:
+
+```
+template.finalizeInstance(name, shareHolders, shareStakes, boardMembers, financePeriod, useAgentAsVault, payrollSettings)
+```
+
+- `payrollSettings`: Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager (set to board voting if 0x0) ] for the Payroll app
 
 ## Deploying templates
 

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -110,7 +110,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _registerID(_id, address(dao));
     }
 
-    function _finalizeApps(Kernel _dao, address[] _shareHolders, uint256[] _shareStakes, address[] _boardMembers, Voting _shareVoting, Voting _boardVoting) internal {
+    function _finalizeApps(Kernel _dao, address[] memory _shareHolders, uint256[] memory _shareStakes, address[] memory _boardMembers, Voting _shareVoting, Voting _boardVoting) internal {
         (MiniMeToken shareToken, MiniMeToken boardToken) = _popTokenCaches();
 
         // Install
@@ -206,7 +206,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         delete c.boardToken;
     }
 
-    function _ensureFinalizationSettings(address[] memory _shareHolders, uint256[] memory _shareStakes, address[] memory _boardMembers) internal {
+    function _ensureFinalizationSettings(address[] memory _shareHolders, uint256[] memory _shareStakes, address[] memory _boardMembers) private pure {
         require(_shareHolders.length > 0, ERROR_MISSING_SHARE_MEMBERS);
         require(_shareHolders.length == _shareStakes.length, ERROR_BAD_HOLDERS_STAKES_LEN);
         require(_boardMembers.length > 0, ERROR_MISSING_BOARD_MEMBERS);

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -4,12 +4,12 @@ import "@aragon/templates-shared/contracts/BaseTemplate.sol";
 
 
 contract CompanyBoardTemplate is BaseTemplate {
-    string constant private ERROR_MISSING_CACHE = "COMPANY_MISSING_CACHE";
-    string constant private ERROR_MISSING_BOARD_MEMBERS = "COMPANY_MISSING_BOARD_MEMBERS";
-    string constant private ERROR_MISSING_SHARE_MEMBERS = "COMPANY_MISSING_SHARE_MEMBERS";
-    string constant private ERROR_BAD_HOLDERS_STAKES_LEN = "COMPANY_BAD_HOLDERS_STAKES_LEN";
-    string constant private ERROR_BAD_VOTE_SETTINGS = "COMPANY_BAD_VOTE_SETTINGS";
-    string constant private ERROR_BAD_PAYROLL_SETTINGS = "COMPANY_BAD_PAYROLL_SETTINGS";
+    string constant private ERROR_MISSING_CACHE = "COMPANYBD_MISSING_CACHE";
+    string constant private ERROR_MISSING_BOARD_MEMBERS = "COMPANYBD_MISSING_BOARD_MEMBERS";
+    string constant private ERROR_MISSING_SHARE_MEMBERS = "COMPANYBD_MISSING_SHARE_MEMBERS";
+    string constant private ERROR_BAD_HOLDERS_STAKES_LEN = "COMPANYBD_BAD_HOLDERS_STAKES_LEN";
+    string constant private ERROR_BAD_VOTE_SETTINGS = "COMPANYBD_BAD_VOTE_SETTINGS";
+    string constant private ERROR_BAD_PAYROLL_SETTINGS = "COMPANYBD_BAD_PAYROLL_SETTINGS";
 
     bool constant private BOARD_TRANSFERABLE = false;
     string constant private BOARD_TOKEN_NAME = "Board Token";

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -48,7 +48,14 @@ contract CompanyBoardTemplate is BaseTemplate {
     * @param _shareVotingSettings Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the share voting app of the organization
     * @param _boardVotingSettings Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the board voting app of the organization
     */
-    function prepareInstance(string _shareTokenName, string _shareTokenSymbol, uint64[3] _shareVotingSettings, uint64[3] _boardVotingSettings) external {
+    function prepareInstance(
+        string _shareTokenName,
+        string _shareTokenSymbol,
+        uint64[3] _shareVotingSettings,
+        uint64[3] _boardVotingSettings
+    )
+        external
+    {
         require(_boardVotingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);
         require(_shareVotingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);
 
@@ -73,7 +80,16 @@ contract CompanyBoardTemplate is BaseTemplate {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function finalizeInstance(string _id, address[] _shareHolders, uint256[] _shareStakes, address[] _boardMembers, uint64 _financePeriod, bool _useAgentAsVault) external {
+    function finalizeInstance(
+        string _id,
+        address[] _shareHolders,
+        uint256[] _shareStakes,
+        address[] _boardMembers,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        external
+    {
         _ensureFinalizationSettings(_shareHolders, _shareStakes, _boardMembers);
 
         (Kernel dao, Voting shareVoting, Voting boardVoting) = _popDaoCache();
@@ -96,7 +112,17 @@ contract CompanyBoardTemplate is BaseTemplate {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the board voting app as the employee manager.
     */
-    function finalizeInstance(string _id, address[] _shareHolders, uint256[] _shareStakes, address[] _boardMembers, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] _payrollSettings) external {
+    function finalizeInstance(
+        string _id,
+        address[] _shareHolders,
+        uint256[] _shareStakes,
+        address[] _boardMembers,
+        uint64 _financePeriod,
+        bool _useAgentAsVault,
+        uint256[4] _payrollSettings
+    )
+        external
+    {
         _ensureFinalizationSettings(_shareHolders, _shareStakes, _boardMembers);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
 
@@ -110,7 +136,16 @@ contract CompanyBoardTemplate is BaseTemplate {
         _registerID(_id, address(dao));
     }
 
-    function _finalizeApps(Kernel _dao, address[] memory _shareHolders, uint256[] memory _shareStakes, address[] memory _boardMembers, Voting _shareVoting, Voting _boardVoting) internal {
+    function _finalizeApps(
+        Kernel _dao,
+        address[] memory _shareHolders,
+        uint256[] memory _shareStakes,
+        address[] memory _boardMembers,
+        Voting _shareVoting,
+        Voting _boardVoting
+    )
+        internal
+    {
         (MiniMeToken shareToken, MiniMeToken boardToken) = _popTokenCaches();
 
         // Install
@@ -131,7 +166,16 @@ contract CompanyBoardTemplate is BaseTemplate {
         _createVotingPermissions(acl, _boardVoting, _shareVoting, boardTokenManager, _shareVoting);
     }
 
-    function _setupVaultAndFinanceApps(Kernel _dao, uint64 _financePeriod, bool _useAgentAsVault, Voting _shareVoting, Voting _boardVoting) internal returns (Finance) {
+    function _setupVaultAndFinanceApps(
+        Kernel _dao,
+        uint64 _financePeriod,
+        bool _useAgentAsVault,
+        Voting _shareVoting,
+        Voting _boardVoting
+    )
+        internal
+        returns (Finance)
+    {
         // Install
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -175,7 +219,15 @@ contract CompanyBoardTemplate is BaseTemplate {
         _acl.createPermission(_shareVoting, _finance, _finance.MANAGE_PAYMENTS_ROLE(), _shareVoting);
     }
 
-    function _cachePreparedDao(Kernel _dao, MiniMeToken _shareToken, MiniMeToken _boardToken, Voting _shareVoting, Voting _boardVoting) internal {
+    function _cachePreparedDao(
+        Kernel _dao,
+        MiniMeToken _shareToken,
+        MiniMeToken _boardToken,
+        Voting _shareVoting,
+        Voting _boardVoting
+    )
+        internal
+    {
         Cache storage c = cache[msg.sender];
         c.dao = address(_dao);
         c.shareToken = address(_shareToken);
@@ -206,7 +258,14 @@ contract CompanyBoardTemplate is BaseTemplate {
         delete c.boardToken;
     }
 
-    function _ensureFinalizationSettings(address[] memory _shareHolders, uint256[] memory _shareStakes, address[] memory _boardMembers) private pure {
+    function _ensureFinalizationSettings(
+        address[] memory _shareHolders,
+        uint256[] memory _shareStakes,
+        address[] memory _boardMembers
+    )
+        private
+        pure
+    {
         require(_shareHolders.length > 0, ERROR_MISSING_SHARE_MEMBERS);
         require(_shareHolders.length == _shareStakes.length, ERROR_BAD_HOLDERS_STAKES_LEN);
         require(_boardMembers.length > 0, ERROR_MISSING_BOARD_MEMBERS);

--- a/templates/company/contracts/CompanyTemplate.sol
+++ b/templates/company/contracts/CompanyTemplate.sol
@@ -56,7 +56,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     * @param _name String with the name for the token used by share holders in the organization
     * @param _symbol String with the symbol for the token used by share holders in the organization
     */
-    function newToken(string _name, string _symbol) public returns (MiniMeToken) {
+    function newToken(string memory _name, string memory _symbol) public returns (MiniMeToken) {
         MiniMeToken token = _createToken(_name, _symbol, TOKEN_DECIMALS);
         _cacheToken(token, msg.sender);
         return token;
@@ -71,7 +71,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string _id, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -91,7 +91,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string _id, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] _payrollSettings) public {
+    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
         _ensureCompanySettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -101,7 +101,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(Kernel _dao, ACL _acl, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -114,7 +114,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         return (finance, voting);
     }
 
-    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] _payrollSettings) internal {
+    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] memory _payrollSettings) internal {
         (address denominationToken, IFeed priceFeed, uint64 rateExpiryTime, address employeeManager) = _unwrapPayrollSettings(_payrollSettings);
         address manager = employeeManager == address(0) ? _voting : employeeManager;
 
@@ -133,12 +133,12 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureCompanySettings(address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint256[4] _payrollSettings) private pure {
+    function _ensureCompanySettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }
 
-    function _ensureCompanySettings(address[] _holders, uint256[] _stakes, uint64[3] _votingSettings) private pure {
+    function _ensureCompanySettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings) private pure {
         require(_holders.length > 0, ERROR_EMPTY_HOLDERS);
         require(_holders.length == _stakes.length, ERROR_BAD_HOLDERS_STAKES_LEN);
         require(_votingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);

--- a/templates/company/contracts/CompanyTemplate.sol
+++ b/templates/company/contracts/CompanyTemplate.sol
@@ -71,7 +71,16 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        public
+    {
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -91,7 +100,17 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault,
+        uint256[4] memory _payrollSettings
+    )
+        public
+    {
         _ensureCompanySettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -101,7 +120,18 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(
+        Kernel _dao,
+        ACL _acl,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        internal
+        returns (Finance, Voting)
+    {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -122,7 +152,16 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
     }
 
-    function _setupPermissions(ACL _acl, Vault _agentOrVault, Voting _voting, Finance _finance, TokenManager _tokenManager, bool _useAgentAsVault) internal {
+    function _setupPermissions(
+        ACL _acl,
+        Vault _agentOrVault,
+        Voting _voting,
+        Finance _finance,
+        TokenManager _tokenManager,
+        bool _useAgentAsVault
+    )
+        internal
+    {
         if (_useAgentAsVault) {
             _createAgentPermissions(_acl, Agent(_agentOrVault), _voting, _voting);
         }
@@ -133,7 +172,15 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureCompanySettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
+    function _ensureCompanySettings(
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint256[4] memory _payrollSettings
+    )
+        private
+        pure
+    {
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }

--- a/templates/company/test/company.js
+++ b/templates/company/test/company.js
@@ -75,17 +75,17 @@ contract('Company', ([_, owner, holder1, holder2, someone]) => {
     assert.equal(installedApps['token-manager'].length, 1, 'should have installed 1 token manager app')
     tokenManager = TokenManager.at(installedApps['token-manager'][0])
 
-    if(apps.agent) {
+    if (apps.agent) {
       assert.equal(installedApps.agent.length, 1, 'should have installed 1 agent app')
       agent = Agent.at(installedApps.agent[0])
     }
 
-    if(apps.vault) {
+    if (apps.vault) {
       assert.equal(installedApps.vault.length, 1, 'should have installed 1 vault app')
       vault = Vault.at(installedApps.vault[0])
     }
 
-    if(apps.payroll) {
+    if (apps.payroll) {
       assert.equal(installedApps.payroll.length, 1, 'should have installed 1 payroll app')
       payroll = Payroll.at(installedApps.payroll[0])
     }

--- a/templates/membership/contracts/MembershipTemplate.sol
+++ b/templates/membership/contracts/MembershipTemplate.sol
@@ -67,7 +67,15 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string memory _id, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _members,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        public
+	{
         _ensureMembershipSettings(_members, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -86,7 +94,16 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string memory _id, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _members,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault,
+        uint256[4] memory _payrollSettings
+    )
+        public
+    {
         _ensureMembershipSettings(_members, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -96,7 +113,17 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(
+        Kernel _dao,
+        ACL _acl,
+        address[] memory _members,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        internal
+        returns (Finance, Voting)
+    {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -117,7 +144,16 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
     }
 
-    function _setupPermissions(ACL _acl, Vault _agentOrVault, Voting _voting, Finance _finance, TokenManager _tokenManager, bool _useAgentAsVault) internal {
+    function _setupPermissions(
+        ACL _acl,
+        Vault _agentOrVault,
+        Voting _voting,
+        Finance _finance,
+        TokenManager _tokenManager,
+        bool _useAgentAsVault
+    )
+        internal
+    {
         if (_useAgentAsVault) {
             _createAgentPermissions(_acl, Agent(_agentOrVault), _voting, _voting);
         }
@@ -128,7 +164,14 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureMembershipSettings(address[] memory _members, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
+    function _ensureMembershipSettings(
+        address[] memory _members,
+        uint64[3] memory _votingSettings,
+        uint256[4] memory _payrollSettings
+    )
+        private
+        pure
+    {
         _ensureMembershipSettings(_members, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }

--- a/templates/membership/contracts/MembershipTemplate.sol
+++ b/templates/membership/contracts/MembershipTemplate.sol
@@ -53,7 +53,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     * @param _name String with the name for the token used by share holders in the organization
     * @param _symbol String with the symbol for the token used by share holders in the organization
     */
-    function newToken(string _name, string _symbol) public returns (MiniMeToken) {
+    function newToken(string memory _name, string memory _symbol) public returns (MiniMeToken) {
         MiniMeToken token = _createToken(_name, _symbol, TOKEN_DECIMALS);
         _cacheToken(token, msg.sender);
         return token;
@@ -67,7 +67,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string _id, address[] _members, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(string memory _id, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
         _ensureMembershipSettings(_members, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -86,7 +86,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string _id, address[] _members, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] _payrollSettings) public {
+    function newInstance(string memory _id, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
         _ensureMembershipSettings(_members, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -96,7 +96,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] _members, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(Kernel _dao, ACL _acl, address[] memory _members, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -109,7 +109,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         return (finance, voting);
     }
 
-    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] _payrollSettings) internal {
+    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] memory _payrollSettings) internal {
         (address denominationToken, IFeed priceFeed, uint64 rateExpiryTime, address employeeManager) = _unwrapPayrollSettings(_payrollSettings);
         address manager = employeeManager == address(0) ? _voting : employeeManager;
 
@@ -128,12 +128,12 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureMembershipSettings(address[] _members, uint64[3] _votingSettings, uint256[4] _payrollSettings) private pure {
+    function _ensureMembershipSettings(address[] memory _members, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
         _ensureMembershipSettings(_members, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }
 
-    function _ensureMembershipSettings(address[] _members, uint64[3] _votingSettings) private pure {
+    function _ensureMembershipSettings(address[] memory _members, uint64[3] memory _votingSettings) private pure {
         require(_members.length > 0, ERROR_MISSING_MEMBERS);
         require(_votingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);
     }

--- a/templates/membership/test/membership.js
+++ b/templates/membership/test/membership.js
@@ -74,17 +74,17 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
     assert.equal(installedApps['token-manager'].length, 1, 'should have installed 1 token manager app')
     tokenManager = TokenManager.at(installedApps['token-manager'][0])
 
-    if(apps.agent) {
+    if (apps.agent) {
       assert.equal(installedApps.agent.length, 1, 'should have installed 1 agent app')
       agent = Agent.at(installedApps.agent[0])
     }
 
-    if(apps.vault) {
+    if (apps.vault) {
       assert.equal(installedApps.vault.length, 1, 'should have installed 1 vault app')
       vault = Vault.at(installedApps.vault[0])
     }
 
-    if(apps.payroll) {
+    if (apps.payroll) {
       assert.equal(installedApps.payroll.length, 1, 'should have installed 1 payroll app')
       payroll = Payroll.at(installedApps.payroll[0])
     }

--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -56,7 +56,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     * @param _name String with the name for the token used by share holders in the organization
     * @param _symbol String with the symbol for the token used by share holders in the organization
     */
-    function newToken(string _name, string _symbol) public returns (MiniMeToken) {
+    function newToken(string memory _name, string memory _symbol) public returns (MiniMeToken) {
         MiniMeToken token = _createToken(_name, _symbol, TOKEN_DECIMALS);
         _cacheToken(token, msg.sender);
         return token;
@@ -71,7 +71,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string _id, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -91,7 +91,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string _id, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] _payrollSettings) public {
+    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
         _ensureReputationSettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -101,7 +101,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(Kernel _dao, ACL _acl, address[] memory _holders, uint256[] memory _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -114,7 +114,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         return (finance, voting);
     }
 
-    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] _payrollSettings) internal {
+    function _setupPayrollApp(Kernel _dao, ACL _acl, Finance _finance, Voting _voting, uint256[4] memory _payrollSettings) internal {
         (address denominationToken, IFeed priceFeed, uint64 rateExpiryTime, address employeeManager) = _unwrapPayrollSettings(_payrollSettings);
         address manager = employeeManager == address(0) ? _voting : employeeManager;
 
@@ -133,12 +133,12 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureReputationSettings(address[] _holders, uint256[] _stakes, uint64[3] _votingSettings, uint256[4] _payrollSettings) private pure {
+    function _ensureReputationSettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }
 
-    function _ensureReputationSettings(address[] _holders, uint256[] _stakes, uint64[3] _votingSettings) private pure {
+    function _ensureReputationSettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings) private pure {
         require(_holders.length > 0, ERROR_EMPTY_HOLDERS);
         require(_holders.length == _stakes.length, ERROR_BAD_HOLDERS_STAKES_LEN);
         require(_votingSettings.length == 3, ERROR_BAD_VOTE_SETTINGS);

--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -71,7 +71,16 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     * @param _financePeriod Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.
     * @param _useAgentAsVault Boolean to tell whether to use an Agent app as a more advanced form of Vault app
     */
-    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        public
+    {
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -91,7 +100,17 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     * @param _payrollSettings Array of [address denominationToken , IFeed priceFeed, uint64 rateExpiryTime, address employeeManager]
              for the payroll app. The `employeeManager` can be set to `0x0` in order to use the voting app as the employee manager.
     */
-    function newInstance(string memory _id, address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint64 _financePeriod, bool _useAgentAsVault, uint256[4] memory _payrollSettings) public {
+    function newInstance(
+        string memory _id,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault,
+        uint256[4] memory _payrollSettings
+    )
+        public
+    {
         _ensureReputationSettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -101,7 +120,18 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _registerID(_id, dao);
     }
 
-    function _setupApps(Kernel _dao, ACL _acl, address[] memory _holders, uint256[] memory _stakes, uint64[3] _votingSettings, uint64 _financePeriod, bool _useAgentAsVault) internal returns (Finance, Voting) {
+    function _setupApps(
+        Kernel _dao,
+        ACL _acl,
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] _votingSettings,
+        uint64 _financePeriod,
+        bool _useAgentAsVault
+    )
+        internal
+        returns (Finance, Voting)
+    {
         MiniMeToken token = _popTokenCache(msg.sender);
         Vault agentOrVault = _useAgentAsVault ? _installDefaultAgentApp(_dao) : _installVaultApp(_dao);
         Finance finance = _installFinanceApp(_dao, agentOrVault, _financePeriod == 0 ? DEFAULT_FINANCE_PERIOD : _financePeriod);
@@ -122,7 +152,16 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
     }
 
-    function _setupPermissions(ACL _acl, Vault _agentOrVault, Voting _voting, Finance _finance, TokenManager _tokenManager, bool _useAgentAsVault) internal {
+    function _setupPermissions(
+        ACL _acl,
+        Vault _agentOrVault,
+        Voting _voting,
+        Finance _finance,
+        TokenManager _tokenManager,
+        bool _useAgentAsVault
+    )
+        internal
+    {
         if (_useAgentAsVault) {
             _createAgentPermissions(_acl, Agent(_agentOrVault), _voting, _voting);
         }
@@ -133,7 +172,15 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);
     }
 
-    function _ensureReputationSettings(address[] memory _holders, uint256[] memory _stakes, uint64[3] memory _votingSettings, uint256[4] memory _payrollSettings) private pure {
+    function _ensureReputationSettings(
+        address[] memory _holders,
+        uint256[] memory _stakes,
+        uint64[3] memory _votingSettings,
+        uint256[4] memory _payrollSettings
+    )
+        private
+        pure
+    {
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
     }

--- a/templates/reputation/test/reputation.js
+++ b/templates/reputation/test/reputation.js
@@ -75,17 +75,17 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
     assert.equal(installedApps['token-manager'].length, 1, 'should have installed 1 token manager app')
     tokenManager = TokenManager.at(installedApps['token-manager'][0])
 
-    if(apps.agent) {
+    if (apps.agent) {
       assert.equal(installedApps.agent.length, 1, 'should have installed 1 agent app')
       agent = Agent.at(installedApps.agent[0])
     }
 
-    if(apps.vault) {
+    if (apps.vault) {
       assert.equal(installedApps.vault.length, 1, 'should have installed 1 vault app')
       vault = Vault.at(installedApps.vault[0])
     }
 
-    if(apps.payroll) {
+    if (apps.payroll) {
       assert.equal(installedApps.payroll.length, 1, 'should have installed 1 payroll app')
       payroll = Payroll.at(installedApps.payroll[0])
     }

--- a/templates/trust/contracts/TrustTemplate.sol
+++ b/templates/trust/contracts/TrustTemplate.sol
@@ -85,7 +85,7 @@ contract TrustTemplate is BaseTemplate {
         return dao;
     }
 
-    function setupInstance(string _id, address[] _beneficiaryKeys, address[] _heirs, uint256[] _heirsStakes) public returns (Kernel) {
+    function setupInstance(string memory _id, address[] memory _beneficiaryKeys, address[] memory _heirs, uint256[] memory _heirsStakes) public returns (Kernel) {
         require(_hasDaoCache(msg.sender), ERROR_MISSING_SENDER_CACHE);
         require(_heirs.length == _heirsStakes.length, ERROR_BAD_HEIRS_LENGTH);
         require(_beneficiaryKeys.length == BENEFICIARY_KEYS_AMOUNT, ERROR_BAD_BENEFICIARY_KEYS_LENGTH);
@@ -97,7 +97,7 @@ contract TrustTemplate is BaseTemplate {
         return dao;
     }
 
-    function setupMultiSig(address[] _multiSigKeys) public returns (MultiSigWallet) {
+    function setupMultiSig(address[] memory _multiSigKeys) public returns (MultiSigWallet) {
         require(_hasDaoCache(msg.sender) && _hasAppsCache(msg.sender), ERROR_MISSING_SENDER_CACHE);
         require(_multiSigKeys.length == MULTI_SIG_EXTERNAL_KEYS_AMOUNT, ERROR_BAD_MULTI_SIG_KEYS_LENGTH);
 
@@ -107,7 +107,7 @@ contract TrustTemplate is BaseTemplate {
         return multiSig;
     }
 
-    function _setupApps(Kernel _dao, address[] _beneficiaryKeys, address[] _heirs, uint256[] _heirsStakes, uint256 _blockedHeirsSupply) internal {
+    function _setupApps(Kernel _dao, address[] memory _beneficiaryKeys, address[] memory _heirs, uint256[] memory _heirsStakes, uint256 _blockedHeirsSupply) internal {
         // Install apps
         ACL acl = ACL(_dao.acl());
         Vault vault = _installVaultApp(_dao);
@@ -133,7 +133,7 @@ contract TrustTemplate is BaseTemplate {
         _storeAppsCache(msg.sender, agent, holdVoting, holdTokenManager, heirsTokenManager);
     }
 
-    function _setupMultiSig(Kernel _dao, address[] _multiSigKeys) internal returns (MultiSigWallet) {
+    function _setupMultiSig(Kernel _dao, address[] memory _multiSigKeys) internal returns (MultiSigWallet) {
         ACL acl = ACL(_dao.acl());
 
         (Agent agent, Voting holdVoting, TokenManager holdTokenManager, TokenManager heirsTokenManager) = _getAppsCache(msg.sender);
@@ -144,7 +144,7 @@ contract TrustTemplate is BaseTemplate {
         return multiSig;
     }
 
-    function _createMultiSig(address[] _multiSigKeys, Agent _agent) internal returns (MultiSigWallet) {
+    function _createMultiSig(address[] memory _multiSigKeys, Agent _agent) internal returns (MultiSigWallet) {
         address[] memory multiSigOwners = new address[](3);
         multiSigOwners[0] = _multiSigKeys[0];
         multiSigOwners[1] = _multiSigKeys[1];
@@ -243,7 +243,7 @@ contract TrustTemplate is BaseTemplate {
         heirsTokenManager = TokenManager(c.heirsTokenManager);
     }
 
-    function _calculateBlockedHeirsSupply(uint256[] _heirsStakes) internal pure returns (uint256) {
+    function _calculateBlockedHeirsSupply(uint256[] memory _heirsStakes) internal pure returns (uint256) {
         uint256 totalHeirsSupply = 0;
         for (uint256 i = 0; i < _heirsStakes.length; i++) {
             totalHeirsSupply = totalHeirsSupply.add(_heirsStakes[i]);

--- a/templates/trust/contracts/TrustTemplate.sol
+++ b/templates/trust/contracts/TrustTemplate.sol
@@ -85,7 +85,15 @@ contract TrustTemplate is BaseTemplate {
         return dao;
     }
 
-    function setupInstance(string memory _id, address[] memory _beneficiaryKeys, address[] memory _heirs, uint256[] memory _heirsStakes) public returns (Kernel) {
+    function setupInstance(
+        string memory _id,
+        address[] memory _beneficiaryKeys,
+        address[] memory _heirs,
+        uint256[] memory _heirsStakes
+    )
+        public
+        returns (Kernel)
+    {
         require(_hasDaoCache(msg.sender), ERROR_MISSING_SENDER_CACHE);
         require(_heirs.length == _heirsStakes.length, ERROR_BAD_HEIRS_LENGTH);
         require(_beneficiaryKeys.length == BENEFICIARY_KEYS_AMOUNT, ERROR_BAD_BENEFICIARY_KEYS_LENGTH);
@@ -107,7 +115,15 @@ contract TrustTemplate is BaseTemplate {
         return multiSig;
     }
 
-    function _setupApps(Kernel _dao, address[] memory _beneficiaryKeys, address[] memory _heirs, uint256[] memory _heirsStakes, uint256 _blockedHeirsSupply) internal {
+    function _setupApps(
+        Kernel _dao,
+        address[] memory _beneficiaryKeys,
+        address[] memory _heirs,
+        uint256[] memory _heirsStakes,
+        uint256 _blockedHeirsSupply
+    )
+        internal
+    {
         // Install apps
         ACL acl = ACL(_dao.acl());
         Vault vault = _installVaultApp(_dao);


### PR DESCRIPTION
Refactors how the Company with Board template is initialized, grouping more like-elements together.

To create a Company with Board, the flow is now:

1. Call `prepareInstance()`, creating an incomplete org with its two voting apps installed, and
1. Call `finalizeInstance()`, to finish setting up the org with token holders and other apps.

Orgs at the end of step 1 (`prepareInstance()`) will be viewable in an Aragon client, but will have their permissions locked such that no votes can be created, and **only** the template is able to continue adding apps, changing permissions, or minting tokens. The previous versions also held this property.

It's not obvious from the tests, but the changes result in ~16k gas being saved in an org without Payroll installed, and a ~1k save when Payroll is installed. It also makes it _slightly_ easier to add larger groups of board members or share holders (each cost ~50-100k gas), since they happen in the second step that requires less overall gas.