### PR TITLE
 Add the ability to pass custom apps to publish

### DIFF
--- a/shared/lib/TemplatesDeployer.js
+++ b/shared/lib/TemplatesDeployer.js
@@ -1,4 +1,3 @@
-const { APPS } = require('../helpers/apps')
 const { hash: namehash } = require('eth-ens-namehash')
 
 const logDeploy = require('@aragon/os/scripts/helpers/deploy-logger')
@@ -12,7 +11,7 @@ module.exports = class TemplateDeployer {
     this.web3 = web3
     this.artifacts = artifacts
     this.owner = owner
-    this.options = { apps: APPS, ...options }
+    this.options = { ...options }
   }
 
   async deploy(templateName, contractName) {

--- a/shared/scripts/deploy-template.js
+++ b/shared/scripts/deploy-template.js
@@ -1,4 +1,5 @@
 const TemplatesDeployer = require('../lib/TemplatesDeployer')
+const { APPS } = require("../helpers/apps");
 const getAccounts = require('@aragon/os/scripts/helpers/get-accounts')
 
 const errorOut = message => {
@@ -6,7 +7,7 @@ const errorOut = message => {
   throw new Error(message)
 }
 
-module.exports = async function deployTemplate(web3, artifacts, templateName, contractName) {
+module.exports = async function deployTemplate(web3, artifacts, templateName, contractName, apps = APPS) {
   let { ens, owner, verbose } = require('yargs')
     .option('e', { alias: 'ens', describe: 'ENS address', type: 'string' })
     .option('o', { alias: 'owner', describe: 'Sender address. Will use first address if no one is given', type: 'string' })
@@ -21,6 +22,6 @@ module.exports = async function deployTemplate(web3, artifacts, templateName, co
   if (!templateName) errorOut('Missing template id.')
   if (!contractName) errorOut('Missing template contract name.')
 
-  const deployer = new TemplatesDeployer(web3, artifacts, owner, { ens, verbose })
+  const deployer = new TemplatesDeployer(web3, artifacts, owner, { apps, ens, verbose })
   return deployer.deploy(templateName, contractName)
 }

--- a/shared/scripts/deploy-template.js
+++ b/shared/scripts/deploy-template.js
@@ -1,5 +1,5 @@
 const TemplatesDeployer = require('../lib/TemplatesDeployer')
-const { APPS } = require("../helpers/apps");
+const { APPS } = require('../helpers/apps')
 const getAccounts = require('@aragon/os/scripts/helpers/get-accounts')
 
 const errorOut = message => {


### PR DESCRIPTION
This will make it easier to write custom kits on top of the existing base architecture [like publishing the fundraising apps before running the tests]