### PR TITLE
Base: Emit an event when an organization has been finalized

### DIFF
--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -55,6 +55,7 @@ contract BaseTemplate is APMNamehash, IsContract {
     IFIFSResolvingRegistrar internal aragonID;
 
     event DeployDao(address dao);
+    event RegisterDao(string id);
     event DeployToken(address token);
     event InstalledApp(address appProxy, bytes32 appId);
 
@@ -320,6 +321,7 @@ contract BaseTemplate is APMNamehash, IsContract {
     function _registerID(string memory _name, address _owner) internal {
         require(address(aragonID) != address(0), ERROR_ARAGON_ID_NOT_PROVIDED);
         aragonID.register(keccak256(abi.encodePacked(_name)), _owner);
+        emit RegisterDao(_name);
     }
 
     function _ensureAragonIdIsValid(address _aragonID) internal view {

--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -55,7 +55,7 @@ contract BaseTemplate is APMNamehash, IsContract {
     IFIFSResolvingRegistrar internal aragonID;
 
     event DeployDao(address dao);
-    event RegisterDao(string id);
+    event SetupDao(address dao);
     event DeployToken(address token);
     event InstalledApp(address appProxy, bytes32 appId);
 
@@ -110,6 +110,7 @@ contract BaseTemplate is APMNamehash, IsContract {
         ACL _acl = ACL(_dao.acl());
         _transferPermissionFromTemplate(_acl, _dao, _to, _dao.APP_MANAGER_ROLE(), _manager);
         _transferPermissionFromTemplate(_acl, _acl, _to, _acl.CREATE_PERMISSIONS_ROLE(), _manager);
+        emit SetupDao(_dao);
     }
 
     function _transferPermissionFromTemplate(ACL _acl, address _app, address _to, bytes32 _permission, address _manager) internal {
@@ -321,7 +322,6 @@ contract BaseTemplate is APMNamehash, IsContract {
     function _registerID(string memory _name, address _owner) internal {
         require(address(aragonID) != address(0), ERROR_ARAGON_ID_NOT_PROVIDED);
         aragonID.register(keccak256(abi.encodePacked(_name)), _owner);
-        emit RegisterDao(_name);
     }
 
     function _ensureAragonIdIsValid(address _aragonID) internal view {

--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -72,8 +72,8 @@ contract BaseTemplate is APMNamehash, IsContract {
     /**
     * @dev Create a DAO using the DAO Factory and grant the template root permissions so it has full
     *      control during setup. Once the DAO setup has finished, it is recommended to call the
-    *      `_transferRootPermissionsFromTemplate()` helper to transfer the root permissions to
-    *      the end entity in control of the organization.
+    *      `_transferRootPermissionsFromTemplateAndFinalizeDAO()` helper to transfer the root
+    *      permissions to the end entity in control of the organization.
     */
     function _createDAO() internal returns (Kernel dao, ACL acl) {
         dao = daoFactory.newDAO(this);
@@ -102,11 +102,11 @@ contract BaseTemplate is APMNamehash, IsContract {
         _acl.removePermissionManager(_app, _permission);
     }
 
-    function _transferRootPermissionsFromTemplate(Kernel _dao, address _to) internal {
-        _transferRootPermissionsFromTemplate(_dao, _to, _to);
+    function _transferRootPermissionsFromTemplateAndFinalizeDAO(Kernel _dao, address _to) internal {
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(_dao, _to, _to);
     }
 
-    function _transferRootPermissionsFromTemplate(Kernel _dao, address _to, address _manager) internal {
+    function _transferRootPermissionsFromTemplateAndFinalizeDAO(Kernel _dao, address _to, address _manager) internal {
         ACL _acl = ACL(_dao.acl());
         _transferPermissionFromTemplate(_acl, _dao, _to, _dao.APP_MANAGER_ROLE(), _manager);
         _transferPermissionFromTemplate(_acl, _acl, _to, _acl.CREATE_PERMISSIONS_ROLE(), _manager);

--- a/templates/bare/contracts/BareTemplate.sol
+++ b/templates/bare/contracts/BareTemplate.sol
@@ -28,6 +28,6 @@ contract BareTemplate is BaseTemplate {
             }
         }
 
-        _transferRootPermissionsFromTemplate(dao, root);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, root);
     }
 }

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -97,7 +97,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupVaultAndFinanceApps(dao, _financePeriod, _useAgentAsVault, shareVoting, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
-        _transferRootPermissionsFromTemplate(dao, boardVoting, shareVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, boardVoting, shareVoting);
         _registerID(_id, address(dao));
     }
 
@@ -132,7 +132,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupPayrollApp(dao, finance, _payrollSettings, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
-        _transferRootPermissionsFromTemplate(dao, boardVoting, shareVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, boardVoting, shareVoting);
         _registerID(_id, address(dao));
     }
 

--- a/templates/company-board/test/company-board.js
+++ b/templates/company-board/test/company-board.js
@@ -104,7 +104,7 @@ contract('Company with board', ([_, owner, boardMember1, boardMember2, shareHold
       const installedAppsDuringPrepare = getInstalledAppsById(prepareReceipt)
       const installedAppsDuringFinalize = getInstalledAppsById(finalizeInstanceReceipt)
 
-      assert.equal(daoID, getEventArgument(finalizeInstanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+      assert.equal(dao.address, getEventArgument(finalizeInstanceReceipt, 'SetupDao', 'dao'), 'should have emitted a SetupDao event')
 
       assert.equal(installedAppsDuringPrepare.voting.length, 2, 'should have installed 2 voting apps during prepare')
       shareVoting = Voting.at(installedAppsDuringPrepare.voting[0])

--- a/templates/company-board/test/company-board.js
+++ b/templates/company-board/test/company-board.js
@@ -104,6 +104,8 @@ contract('Company with board', ([_, owner, boardMember1, boardMember2, shareHold
       const installedAppsDuringPrepare = getInstalledAppsById(prepareReceipt)
       const installedAppsDuringFinalize = getInstalledAppsById(finalizeInstanceReceipt)
 
+      assert.equal(daoID, getEventArgument(finalizeInstanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+
       assert.equal(installedAppsDuringPrepare.voting.length, 2, 'should have installed 2 voting apps during prepare')
       shareVoting = Voting.at(installedAppsDuringPrepare.voting[0])
       boardVoting = Voting.at(installedAppsDuringPrepare.voting[1])

--- a/templates/company/contracts/CompanyTemplate.sol
+++ b/templates/company/contracts/CompanyTemplate.sol
@@ -85,7 +85,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
 
         (Kernel dao, ACL acl) = _createDAO();
         (, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 
@@ -116,7 +116,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 

--- a/templates/company/test/company.js
+++ b/templates/company/test/company.js
@@ -66,7 +66,7 @@ contract('Company', ([_, owner, holder1, holder2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
-    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+    assert.equal(dao.address, getEventArgument(instanceReceipt, 'SetupDao', 'dao'), 'should have emitted a SetupDao event')
 
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])

--- a/templates/company/test/company.js
+++ b/templates/company/test/company.js
@@ -66,6 +66,8 @@ contract('Company', ([_, owner, holder1, holder2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
+    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])
 

--- a/templates/membership/contracts/MembershipTemplate.sol
+++ b/templates/membership/contracts/MembershipTemplate.sol
@@ -80,7 +80,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
 
         (Kernel dao, ACL acl) = _createDAO();
         (, Voting voting) = _setupApps(dao, acl, _members, _votingSettings, _financePeriod, _useAgentAsVault);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 
@@ -109,7 +109,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _members, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 

--- a/templates/membership/test/membership.js
+++ b/templates/membership/test/membership.js
@@ -65,7 +65,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
-    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+    assert.equal(dao.address, getEventArgument(instanceReceipt, 'SetupDao', 'dao'), 'should have emitted a SetupDao event')
 
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])

--- a/templates/membership/test/membership.js
+++ b/templates/membership/test/membership.js
@@ -65,6 +65,8 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
+    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])
 
@@ -244,7 +246,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const USE_AGENT_AS_VAULT = true
 
           createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-          itCostsUpTo(6.7e6)
+          itCostsUpTo(6.71e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
         })
@@ -266,7 +268,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const USE_AGENT_AS_VAULT = true
 
           createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-          itCostsUpTo(6.7e6)
+          itCostsUpTo(6.71e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
         })

--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -85,7 +85,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
 
         (Kernel dao, ACL acl) = _createDAO();
         (, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 
@@ -116,7 +116,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
-        _transferRootPermissionsFromTemplate(dao, voting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
 

--- a/templates/reputation/test/reputation.js
+++ b/templates/reputation/test/reputation.js
@@ -66,6 +66,8 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
+    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])
 

--- a/templates/reputation/test/reputation.js
+++ b/templates/reputation/test/reputation.js
@@ -66,7 +66,7 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
     acl = ACL.at(await dao.acl())
     const installedApps = getInstalledAppsById(instanceReceipt)
 
-    assert.equal(daoID, getEventArgument(instanceReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+    assert.equal(dao.address, getEventArgument(instanceReceipt, 'SetupDao', 'dao'), 'should have emitted a SetupDao event')
 
     assert.equal(installedApps.voting.length, 1, 'should have installed 1 voting app')
     voting = Voting.at(installedApps.voting[0])

--- a/templates/trust/contracts/TrustTemplate.sol
+++ b/templates/trust/contracts/TrustTemplate.sol
@@ -155,7 +155,7 @@ contract TrustTemplate is BaseTemplate {
         (Agent agent, Voting holdVoting, TokenManager holdTokenManager, TokenManager heirsTokenManager) = _getAppsCache(msg.sender);
         MultiSigWallet multiSig = _createMultiSig(_multiSigKeys, agent);
         _createMultiSigPermissions(acl, multiSig, holdTokenManager, heirsTokenManager);
-        _transferRootPermissionsFromTemplate(_dao, holdVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(_dao, holdVoting);
         _cleanCache(msg.sender);
         return multiSig;
     }

--- a/templates/trust/test/trust.js
+++ b/templates/trust/test/trust.js
@@ -98,6 +98,8 @@ contract('Trust', ([_, owner, beneficiaryKey1, beneficiaryKey2, heir1, heir2, mu
       holdToken = MiniMeToken.at(getEventArgument(prepareReceipt, 'DeployToken', 'token', 0))
       heirsToken = MiniMeToken.at(getEventArgument(prepareReceipt, 'DeployToken', 'token', 1))
       multiSig = MultiSigWallet.at(getEventArgument(multiSigSetupReceipt, 'DeployMultiSig', 'multiSig'))
+
+      assert.equal(daoID, getEventArgument(setupReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
     })
 
     before('load apps', async () => {

--- a/templates/trust/test/trust.js
+++ b/templates/trust/test/trust.js
@@ -99,7 +99,7 @@ contract('Trust', ([_, owner, beneficiaryKey1, beneficiaryKey2, heir1, heir2, mu
       heirsToken = MiniMeToken.at(getEventArgument(prepareReceipt, 'DeployToken', 'token', 1))
       multiSig = MultiSigWallet.at(getEventArgument(multiSigSetupReceipt, 'DeployMultiSig', 'multiSig'))
 
-      assert.equal(daoID, getEventArgument(setupReceipt, 'RegisterDao', 'id'), 'should have emitted RegisterDao event with the correct id')
+      assert.equal(dao.address, getEventArgument(multiSigSetupReceipt, 'SetupDao', 'dao'), 'should have emitted a SetupDao event')
     })
 
     before('load apps', async () => {
@@ -123,7 +123,7 @@ contract('Trust', ([_, owner, beneficiaryKey1, beneficiaryKey2, heir1, heir2, mu
     it('costs ~12.51e6 gas', async () => {
       assert.isAtMost(prepareReceipt.receipt.gasUsed, 5.00e6, 'prepare script should cost almost 5.00e6 gas')
       assert.isAtMost(setupReceipt.receipt.gasUsed, 5.67e6, 'setup script should cost almost 5.67e6 gas')
-      assert.isAtMost(multiSigSetupReceipt.receipt.gasUsed, 1.84e6, 'multisig script should cost almost 1.84e6 gas')
+      assert.isAtMost(multiSigSetupReceipt.receipt.gasUsed, 1.85e6, 'multisig script should cost almost 1.85e6 gas')
     })
 
     it('registers a new DAO on ENS', async () => {


### PR DESCRIPTION
Kept the original **DeployDao** event when a DAO is created, and added a new **RegisterDao** event to represent the finalization of the template, since the last thing all templates do is call `_registerID(...)`.

The RegisterDao event carries the parameter `string id`, with the ID that the DAO is registered with, and this event + value are checked for on all tests.