### PR TITLE
Templates: upgrade to apps-agent@2

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -13,7 +13,7 @@
     "docker-compose.yml"
   ],
   "dependencies": {
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-finance": "^3.0.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",
     "@aragon/apps-shared-migrations": "^1.0.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -13,7 +13,7 @@
     "docker-compose.yml"
   ],
   "dependencies": {
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-finance": "^3.0.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",
     "@aragon/apps-shared-migrations": "^1.0.0",

--- a/templates/bare/package.json
+++ b/templates/bare/package.json
@@ -35,7 +35,7 @@
     "@aragon/templates-shared": "^1.0.0-rc.1"
   },
   "devDependencies": {
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",

--- a/templates/bare/package.json
+++ b/templates/bare/package.json
@@ -35,7 +35,7 @@
     "@aragon/templates-shared": "^1.0.0-rc.1"
   },
   "devDependencies": {
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",

--- a/templates/company-board/package.json
+++ b/templates/company-board/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/company-board/package.json
+++ b/templates/company-board/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/company/package.json
+++ b/templates/company/package.json
@@ -37,7 +37,7 @@
     "publish:mainnet": "aragon apm publish major $(npm run deploy:mainnet | tail -n 1) --environment mainnet"
   },
   "dependencies": {
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-finance": "^3.0.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",
     "@aragon/apps-shared-minime": "^1.0.0",

--- a/templates/company/package.json
+++ b/templates/company/package.json
@@ -37,7 +37,7 @@
     "publish:mainnet": "aragon apm publish major $(npm run deploy:mainnet | tail -n 1) --environment mainnet"
   },
   "dependencies": {
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-finance": "^3.0.0",
     "@aragon/apps-payroll": "^1.0.0-rc.1",
     "@aragon/apps-shared-minime": "^1.0.0",

--- a/templates/membership/package.json
+++ b/templates/membership/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/membership/package.json
+++ b/templates/membership/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/reputation/package.json
+++ b/templates/reputation/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/reputation/package.json
+++ b/templates/reputation/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/trust/package.json
+++ b/templates/trust/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^1.0.0",
+    "@aragon/apps-agent": "^2.0.0-rc.1",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",

--- a/templates/trust/package.json
+++ b/templates/trust/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@aragon/os": "4.2.0",
     "@aragon/id": "2.0.3",
-    "@aragon/apps-agent": "^2.0.0-rc.1",
+    "@aragon/apps-agent": "^2.0.0",
     "@aragon/apps-vault": "^4.1.0",
     "@aragon/apps-voting": "^2.1.0",
     "@aragon/apps-finance": "^3.0.0",


### PR DESCRIPTION
Updates the dependencies to use the latest version; will re-update once both Payroll and Agent are out of release candidate versioning on npm.

**This should have no effect on the compiled contracts; it simply allows us to use the Agent's newer features / roles at a later time in the templates if we choose to do so. The apps themselves are always fetched via their latest published aragonPM version.**