### PR TITLE
Audit review 6.1: Move APP_MANAGER role to shareholders

### DIFF
--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -50,8 +50,8 @@ The network details will be automatically selected by the `arapp.json`'s environ
 
 | App                 | Permission            | Grantee             | Manager       |
 |---------------------|-----------------------|---------------------|---------------|
-| Kernel              | APP_MANAGER           | Board Voting        | Share Voting  |
-| ACL                 | CREATE_PERMISSIONS    | Board Voting        | Share Voting  |
+| Kernel              | APP_MANAGER           | Share Voting        | Share Voting  |
+| ACL                 | CREATE_PERMISSIONS    | Share Voting        | Share Voting  |
 | EVMScriptRegistry   | REGISTRY_MANAGER      | Share Voting        | Share Voting  |
 | EVMScriptRegistry   | REGISTRY_ADD_EXECUTOR | Share Voting        | Share Voting  |
 | Board Voting        | CREATE_VOTES          | Board Token Manager | Share Voting  |

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -97,7 +97,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupVaultAndFinanceApps(dao, _financePeriod, _useAgentAsVault, shareVoting, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
-        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting, shareVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting);
         _registerID(_id, address(dao));
     }
 
@@ -132,7 +132,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupPayrollApp(dao, finance, _payrollSettings, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
-        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, boardVoting, shareVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting);
         _registerID(_id, address(dao));
     }
 

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -97,7 +97,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupVaultAndFinanceApps(dao, _financePeriod, _useAgentAsVault, shareVoting, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
-        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, boardVoting, shareVoting);
+        _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting, shareVoting);
         _registerID(_id, address(dao));
     }
 

--- a/templates/company-board/test/company-board.js
+++ b/templates/company-board/test/company-board.js
@@ -241,8 +241,8 @@ contract('Company with board', ([_, owner, boardMember1, boardMember2, shareHold
       })
 
       it('sets up DAO and ACL permissions correctly', async () => {
-        await assertRole(acl, dao, shareVoting, 'APP_MANAGER_ROLE', boardVoting)
-        await assertRole(acl, acl, shareVoting, 'CREATE_PERMISSIONS_ROLE', boardVoting)
+        await assertRole(acl, dao, shareVoting, 'APP_MANAGER_ROLE')
+        await assertRole(acl, acl, shareVoting, 'CREATE_PERMISSIONS_ROLE')
       })
 
       it('sets up EVM scripts registry permissions correctly', async () => {


### PR DESCRIPTION
#### Problem:
Since BoardVoting is given the APP_MANAGER role, the board could perform malicious installs on an organization and eventually circumvent the share holders.

#### Solution:
Assign APP_MANAGER and CREATE_PERMISSIONS_ROLE to ShareVoting instead of BoardVoting.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#61-company-board---kernelapp_manager-permission-should-be-ruled-by-shareholders-instead-of-board-members