### PR TITLE
Audit review 6.2: Fix role in READMEs

### DIFF
--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -64,7 +64,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 | Finance             | CREATE_PAYMENTS       | Board Voting        | Share Voting  |
 | Finance             | CREATE_PAYMENTS       | Share Voting        | Share Voting  |
 | Finance             | EXECUTE_PAYMENTS      | Share Voting        | Share Voting  |
-| Finance             | DISABLE_PAYMENTS      | Share Voting        | Share Voting  |
+| Finance             | MANAGE_PAYMENTS       | Share Voting        | Share Voting  |
 | Board Token Manager | MINT                  | Share Voting        | Share Voting  |
 | Board Token Manager | BURN                  | Share Voting        | Share Voting  |
 | Share Token Manager | MINT                  | Share Voting        | Share Voting  |

--- a/templates/company/README.md
+++ b/templates/company/README.md
@@ -58,7 +58,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 | Agent or Vault    | TRANSFER              | Finance       | Voting  |
 | Finance           | CREATE_PAYMENTS       | Voting        | Voting  |
 | Finance           | EXECUTE_PAYMENTS      | Voting        | Voting  |
-| Finance           | DISABLE_PAYMENTS      | Voting        | Voting  |
+| Finance           | MANAGE_PAYMENTS       | Voting        | Voting  |
 | Token Manager     | MINT                  | Voting        | Voting  |
 | Token Manager     | BURN                  | Voting        | Voting  |
 

--- a/templates/membership/README.md
+++ b/templates/membership/README.md
@@ -57,7 +57,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 | Agent or Vault    | TRANSFER              | Finance       | Voting  |
 | Finance           | CREATE_PAYMENTS       | Voting        | Voting  |
 | Finance           | EXECUTE_PAYMENTS      | Voting        | Voting  |
-| Finance           | DISABLE_PAYMENTS      | Voting        | Voting  |
+| Finance           | MANAGE_PAYMENTS       | Voting        | Voting  |
 | Token Manager     | MINT                  | Voting        | Voting  |
 | Token Manager     | BURN                  | Voting        | Voting  |
 

--- a/templates/reputation/README.md
+++ b/templates/reputation/README.md
@@ -58,7 +58,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 | Agent or Vault    | TRANSFER              | Finance       | Voting  |
 | Finance           | CREATE_PAYMENTS       | Voting        | Voting  |
 | Finance           | EXECUTE_PAYMENTS      | Voting        | Voting  |
-| Finance           | DISABLE_PAYMENTS      | Voting        | Voting  |
+| Finance           | MANAGE_PAYMENTS       | Voting        | Voting  |
 | Token Manager     | MINT                  | Voting        | Voting  |
 | Token Manager     | BURN                  | Voting        | Voting  |
 

--- a/templates/trust/README.md
+++ b/templates/trust/README.md
@@ -84,7 +84,7 @@ Aragon Trusts are composed of two sub-groups:
 | Vault                 | TRANSFER              | Finance             | Hold Voting        |
 | Finance               | CREATE_PAYMENTS       | Hold Voting         | Hold Voting        |
 | Finance               | EXECUTE_PAYMENTS      | Hold Voting         | Hold Voting        |
-| Finance               | DISABLE_PAYMENTS      | Hold Voting         | Hold Voting        |
+| Finance               | MANAGE_PAYMENTS       | Hold Voting         | Hold Voting        |
 | Hold Token Manager    | MINT                  | Multisig            | Multisig           |
 | Hold Token Manager    | BURN                  | Multisig            | Multisig           |
 | Hold Token Manager    | ASSIGN                | Hold Voting         | Hold Voting        |


### PR DESCRIPTION
#### Problem:
Most of the template READMEs list the DISABLE_PAYMENTS role for finance, which doesn't exist, and don't list the MANAGE_PAYMENTS role which does.

#### Solution:
Replace DISABLE_PAYMENTS with MANAGE_PAYMENTS in all READMEs.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#62-inconsistent-permission-specification-disable_payments