### PR TITLE
Audit review 6.3: No Agent permissions for shareholders

### DIFF
--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -75,9 +75,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 | App                 | Permission            | Grantee             | Manager       |
 |---------------------|-----------------------|---------------------|---------------|
 | Agent               | RUN_SCRIPT            | Board Voting        | Share Voting  |
-| Agent               | RUN_SCRIPT            | Share Voting        | Share Voting  |
 | Agent               | EXECUTE               | Board Voting        | Share Voting  |
-| Agent               | EXECUTE               | Share Voting        | Share Voting  |
 
 ### Additional permissions if the Payroll app is installed
 

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -201,12 +201,8 @@ contract CompanyBoardTemplate is BaseTemplate {
     }
 
     function _createCustomAgentPermissions(ACL _acl, Agent _agent, Voting _shareVoting, Voting _boardVoting) internal {
-        address[] memory grantees = new address[](2);
-        grantees[0] = address(_shareVoting);
-        grantees[1] = address(_boardVoting);
-
-        _createPermissions(_acl, grantees, _agent, _agent.EXECUTE_ROLE(), _shareVoting);
-        _createPermissions(_acl, grantees, _agent, _agent.RUN_SCRIPT_ROLE(), _shareVoting);
+        _acl.createPermission(_boardVoting, _agent, _agent.EXECUTE_ROLE(), _shareVoting);
+        _acl.createPermission(_boardVoting, _agent, _agent.RUN_SCRIPT_ROLE(), _shareVoting);
     }
 
     function _createCustomFinancePermissions(ACL _acl, Finance _finance, Voting _shareVoting, Voting _boardVoting) internal {

--- a/templates/company-board/test/company-board.js
+++ b/templates/company-board/test/company-board.js
@@ -261,8 +261,6 @@ contract('Company with board', ([_, owner, boardMember1, boardMember2, shareHold
         assert.equal(web3.toChecksumAddress(await finance.vault()), agent.address, 'finance vault is not linked to the agent app')
         assert.equal(web3.toChecksumAddress(await dao.getRecoveryVault()), agent.address, 'agent app is not being used as the vault app of the DAO')
 
-        await assertRole(acl, agent, shareVoting, 'EXECUTE_ROLE')
-        await assertRole(acl, agent, shareVoting, 'RUN_SCRIPT_ROLE')
         await assertRole(acl, agent, shareVoting, 'EXECUTE_ROLE', boardVoting)
         await assertRole(acl, agent, shareVoting, 'RUN_SCRIPT_ROLE', boardVoting)
         await assertRole(acl, agent, shareVoting, 'TRANSFER_ROLE', finance)


### PR DESCRIPTION
#### Problem:
The Agent's EXECUTE_ROLE and RUN_SCRIPT_ROLE should be considered "executive" roles, and as so should be assigned only to the board and not the shareholders.

#### Solution:
Assign the roles only to BoardVoting.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#63-company-board---inconsistent-permissions-in-agent-application