### PR TITLE
Audit review 6.6: Missing memory keyword

### DIFF
--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -125,7 +125,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         ACL _acl,
         address[] memory _holders,
         uint256[] memory _stakes,
-        uint64[3] _votingSettings,
+        uint64[3] memory _votingSettings,
         uint64 _financePeriod,
         bool _useAgentAsVault
     )


### PR DESCRIPTION
#### Problem:
There was a missing memory keyword in ReputationTemplate L128.

#### Fix:
Added it! At first, it seemed that other memory keywords were missing, but it can't be used in `external` functions, so they're correct in just reporting this single one.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#66-reputation---missing-data-location-for-argument 