### PR TITLE
Audit review 6.7: Replace parameter name in READMEs

### DIFF
--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -21,7 +21,7 @@ Finalize company-board entity:
 template.finalizeInstance(name, shareHolders, shareStakes, boardMembers, financePeriod, useAgentAsVault)
 ```
 
-- `name`: Name for org, will assign `[name].aragonid.eth`
+- `id`: Id for org, will assign `[id].aragonid.eth`
 - `shareHolders`: Array of share holder addresses
 - `shareStakes`: Array of token stakes for share holders (token has 18 decimals, multiply token amount `* 10^18`)
 - `boardMembers`: Array of board member addresses (1 token will be minted for each board member)

--- a/templates/company/README.md
+++ b/templates/company/README.md
@@ -19,7 +19,7 @@ Create a new company entity:
 template.newInstance(name, holders, stakes, votingSettings, financePeriod, useAgentAsVault)
 ```
 
-- `name`: Name for org, will assign `[name].aragonid.eth`
+- `id`: Id for org, will assign `[id].aragonid.eth`
 - `holders`: Array of token holder addresses
 - `stakes`: Array of token stakes for holders (token has 18 decimals, multiply token amount `* 10^18`)
 - `votingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization

--- a/templates/membership/README.md
+++ b/templates/membership/README.md
@@ -19,7 +19,7 @@ Create a new membership entity:
 template.newInstance(name, members, votingSettings, financePeriod, useAgentAsVault)
 ```
 
-- `name`: Name for org, will assign `[name].aragonid.eth`
+- `id`: Id for org, will assign `[id].aragonid.eth`
 - `members`: Array of member addresses (1 token will be minted for each member)
 - `votingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization
 - `financePeriod`: Initial duration for accounting periods, it can be set to zero in order to use the default of 30 days.

--- a/templates/reputation/README.md
+++ b/templates/reputation/README.md
@@ -19,7 +19,7 @@ Create a new reputation entity:
 template.newInstance(id, holders, stakes, votingSettings, financePeriod, useAgentAsVault)
 ```
 
-- `name`: Name for org, will assign `[name].aragonid.eth`
+- `id`: Id for org, will assign `[id].aragonid.eth`
 - `holders`: Array of token holder addresses
 - `stakes`: Array of token stakes for holders (token has 18 decimals, multiply token amount `* 10^18`)
 - `votingSettings`: Array of [supportRequired, minAcceptanceQuorum, voteDuration] to set up the voting app of the organization

--- a/templates/trust/README.md
+++ b/templates/trust/README.md
@@ -109,7 +109,7 @@ Setup trust DAO:
 template.setupInstance(name, beneficiaryKeys, heirs, heirsStakes)
 ```
 
-- `name`: Name for org, will assign `[name].aragonid.eth`
+- `id`: Id for org, will assign `[id].aragonid.eth`
 - `beneficiaryKeys`: 2-length array with the beneficiaries keys
 - `heirs`: Array of heirs addresses
 - `stakes`: Array of token stakes for heirs (token has 18 decimals, multiply token amount `* 10^18`)


### PR DESCRIPTION
#### Problem:
Docs refer to a `name` parameter which is `id` in the code.

#### Solution:
Rename to `id` in docs.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#67-specification-inconsistencies