### PR TITLE
Audit review 6.8: Validating app id in all templates

### DIFF
--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -320,7 +320,7 @@ contract BaseTemplate is APMNamehash, IsContract {
 
     /* IDS */
 
-    function _validateId(string memory _id) internal {
+    function _validateId(string memory _id) internal pure {
         require(bytes(_id).length > 0, ERROR_INVALID_ID);
     }
 

--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -48,6 +48,7 @@ contract BaseTemplate is APMNamehash, IsContract {
     string constant private ERROR_MINIME_FACTORY_NOT_PROVIDED = "TEMPLATE_MINIME_FAC_NOT_PROVIDED";
     string constant private ERROR_MINIME_FACTORY_NOT_CONTRACT = "TEMPLATE_MINIME_FAC_NOT_CONTRACT";
     string constant private ERROR_CANNOT_CAST_VALUE_TO_ADDRESS = "TEMPLATE_CANNOT_CAST_VALUE_TO_ADDRESS";
+    string constant private ERROR_INVALID_ID = "TEMPLATE_INVALID_ID";
 
     ENS internal ens;
     DAOFactory internal daoFactory;
@@ -318,6 +319,10 @@ contract BaseTemplate is APMNamehash, IsContract {
     }
 
     /* IDS */
+
+    function _validateId(string memory _id) internal {
+        require(bytes(_id).length > 0, ERROR_INVALID_ID);
+    }
 
     function _registerID(string memory _name, address _owner) internal {
         require(address(aragonID) != address(0), ERROR_ARAGON_ID_NOT_PROVIDED);

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -90,6 +90,7 @@ contract CompanyBoardTemplate is BaseTemplate {
     )
         external
     {
+        _validateId(_id);
         _ensureFinalizationSettings(_shareHolders, _shareStakes, _boardMembers);
 
         (Kernel dao, Voting shareVoting, Voting boardVoting) = _popDaoCache();
@@ -123,6 +124,7 @@ contract CompanyBoardTemplate is BaseTemplate {
     )
         external
     {
+        _validateId(_id);
         _ensureFinalizationSettings(_shareHolders, _shareStakes, _boardMembers);
         require(_payrollSettings.length == 4, ERROR_BAD_PAYROLL_SETTINGS);
 

--- a/templates/company-board/test/company-board.js
+++ b/templates/company-board/test/company-board.js
@@ -89,6 +89,10 @@ contract('Company with board', ([_, owner, boardMember1, boardMember2, shareHold
         await assertRevert(finalizeInstance(randomId(), [shareHolder1], SHARE_STAKES, BOARD_MEMBERS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANYBD_BAD_HOLDERS_STAKES_LEN')
         await assertRevert(finalizeInstance(randomId(), SHARE_HOLDERS, [1e18], BOARD_MEMBERS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANYBD_BAD_HOLDERS_STAKES_LEN')
       })
+
+      it('reverts when an empty id is provided', async () => {
+        await assertRevert(finalizeInstance('', SHARE_HOLDERS, SHARE_STAKES, BOARD_MEMBERS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
+      })
     })
   })
 

--- a/templates/company/contracts/CompanyTemplate.sol
+++ b/templates/company/contracts/CompanyTemplate.sol
@@ -81,6 +81,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     )
         public
     {
+        _validateId(_id);
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -111,6 +112,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
     )
         public
     {
+        _validateId(_id);
         _ensureCompanySettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();

--- a/templates/company/test/company.js
+++ b/templates/company/test/company.js
@@ -226,6 +226,10 @@ contract('Company', ([_, owner, holder1, holder2, someone]) => {
         await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, randomId(), [holder1], STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANY_BAD_HOLDERS_STAKES_LEN')
         await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, randomId(), HOLDERS, [1e18], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANY_BAD_HOLDERS_STAKES_LEN')
       })
+
+      it('reverts when an empty id is provided', async () => {
+        await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, '', HOLDERS, STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
+      })
     })
 
     context('when the creation succeeds', () => {
@@ -314,6 +318,10 @@ contract('Company', ([_, owner, holder1, holder2, someone]) => {
         it('reverts when holders and stakes length do not match', async () => {
           await assertRevert(newInstance(randomId(), [holder1], STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANY_BAD_HOLDERS_STAKES_LEN')
           await assertRevert(newInstance(randomId(), HOLDERS, [1e18], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'COMPANY_BAD_HOLDERS_STAKES_LEN')
+        })
+
+        it('reverts when an empty id is provided', async () => {
+          await assertRevert(newInstance('', HOLDERS, STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
         })
       })
     })

--- a/templates/membership/contracts/MembershipTemplate.sol
+++ b/templates/membership/contracts/MembershipTemplate.sol
@@ -76,6 +76,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     )
         public
 	{
+        _validateId(_id);
         _ensureMembershipSettings(_members, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -104,6 +105,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
     )
         public
     {
+        _validateId(_id);
         _ensureMembershipSettings(_members, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();

--- a/templates/membership/test/membership.js
+++ b/templates/membership/test/membership.js
@@ -220,6 +220,10 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
       it('reverts when no members were given', async () => {
         await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, randomId(), [], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'MEMBERSHIP_MISSING_MEMBERS')
       })
+
+      it('reverts when an empty id is provided', async () => {
+        await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, '', MEMBERS, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
+      })
     })
 
     context('when the creation succeeds', () => {
@@ -303,6 +307,10 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
 
         it('reverts when no members were given', async () => {
           await assertRevert(newInstance(randomId(), [], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'MEMBERSHIP_MISSING_MEMBERS')
+        })
+
+        it('reverts when an empty id is provided', async () => {
+          await assertRevert(newInstance('', MEMBERS, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
         })
       })
     })

--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -81,6 +81,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     )
         public
     {
+        _validateId(_id);
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
@@ -111,6 +112,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
     )
         public
     {
+        _validateId(_id);
         _ensureReputationSettings(_holders, _stakes, _votingSettings, _payrollSettings);
 
         (Kernel dao, ACL acl) = _createDAO();

--- a/templates/reputation/test/reputation.js
+++ b/templates/reputation/test/reputation.js
@@ -226,6 +226,10 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
         await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, randomId(), [holder1], STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'REPUTATION_BAD_HOLDERS_STAKES_LEN')
         await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, randomId(), HOLDERS, [1e18], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'REPUTATION_BAD_HOLDERS_STAKES_LEN')
       })
+
+      it('reverts when an empty id is provided', async () => {
+        await assertRevert(template.newTokenAndInstance(TOKEN_NAME, TOKEN_SYMBOL, '', HOLDERS, STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
+      })
     })
 
     context('when the creation succeeds', () => {
@@ -314,6 +318,10 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
         it('reverts when holders and stakes length do not match', async () => {
           await assertRevert(newInstance(randomId(), [holder1], STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'REPUTATION_BAD_HOLDERS_STAKES_LEN')
           await assertRevert(newInstance(randomId(), HOLDERS, [1e18], VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'REPUTATION_BAD_HOLDERS_STAKES_LEN')
+        })
+
+        it('reverts when an empty id is provided', async () => {
+          await assertRevert(newInstance('', HOLDERS, STAKES, VOTING_SETTINGS, FINANCE_PERIOD, USE_AGENT_AS_VAULT), 'TEMPLATE_INVALID_ID')
         })
       })
     })

--- a/templates/trust/contracts/TrustTemplate.sol
+++ b/templates/trust/contracts/TrustTemplate.sol
@@ -94,6 +94,7 @@ contract TrustTemplate is BaseTemplate {
         public
         returns (Kernel)
     {
+        _validateId(_id);
         require(_hasDaoCache(msg.sender), ERROR_MISSING_SENDER_CACHE);
         require(_heirs.length == _heirsStakes.length, ERROR_BAD_HEIRS_LENGTH);
         require(_beneficiaryKeys.length == BENEFICIARY_KEYS_AMOUNT, ERROR_BAD_BENEFICIARY_KEYS_LENGTH);

--- a/templates/trust/test/trust.js
+++ b/templates/trust/test/trust.js
@@ -68,6 +68,10 @@ contract('Trust', ([_, owner, beneficiaryKey1, beneficiaryKey2, heir1, heir2, mu
         await assertRevert(template.setupInstance(daoID, BENEFICIARY_KEYS, HEIRS, [1e18, 1e18]), 'TRUST_INVALID_HEIRS_STAKE')
       })
 
+      it('reverts when an empty id is provided', async () => {
+        await assertRevert(template.setupInstance('', BENEFICIARY_KEYS, HEIRS, HEIRS_STAKE), 'TEMPLATE_INVALID_ID')
+      })
+
       context('when there was no DAO setup', () => {
         it('reverts when trying to setup a new multisig wallet', async () => {
           await assertRevert(template.setupMultiSig(MULTI_SIG_KEYS), 'TRUST_MISSING_SENDER_CACHE')
@@ -79,7 +83,7 @@ contract('Trust', ([_, owner, beneficiaryKey1, beneficiaryKey2, heir1, heir2, mu
           await template.setupInstance(daoID, BENEFICIARY_KEYS, HEIRS, HEIRS_STAKE)
         })
 
-        it('reverts when then given multi sig keys are not 2', async () => {
+        it('reverts when the given multi sig keys are not 2', async () => {
           await assertRevert(template.setupMultiSig([multiSigKey1]), 'TRUST_BAD_MULTI_SIG_KEYS_LENGTH')
           await assertRevert(template.setupMultiSig([multiSigKey1, multiSigKey2, heir1]), 'TRUST_BAD_MULTI_SIG_KEYS_LENGTH')
         })


### PR DESCRIPTION
#### Problem:
If an empty app id is provided, initialization will fail, but late, wasting a lot of gas.

#### Solution:
Check and fail early with a `_validateId(...)` function added to BaseTemplate, called from all templates. Also added tests for this.

#### Audit issue:
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#68-input-validation---aragonid-should-be-checked-for-empty-string