### PR TITLE
Audit review 6.5: Payroll is missing permissions to create payments on Finance

### DIFF
--- a/shared/contracts/BaseTemplate.sol
+++ b/shared/contracts/BaseTemplate.sol
@@ -268,9 +268,20 @@ contract BaseTemplate is APMNamehash, IsContract {
     }
 
     function _createFinancePermissions(ACL _acl, Finance _finance, address _grantee, address _manager) internal {
-        _acl.createPermission(_grantee, _finance, _finance.CREATE_PAYMENTS_ROLE(), _manager);
         _acl.createPermission(_grantee, _finance, _finance.EXECUTE_PAYMENTS_ROLE(), _manager);
         _acl.createPermission(_grantee, _finance, _finance.MANAGE_PAYMENTS_ROLE(), _manager);
+    }
+
+    function _createFinanceCreatePaymentsPermission(ACL _acl, Finance _finance, address _grantee, address _manager) internal {
+        _acl.createPermission(_grantee, _finance, _finance.CREATE_PAYMENTS_ROLE(), _manager);
+    }
+
+    function _grantCreatePaymentPermission(ACL _acl, Finance _finance, address _to) internal {
+        _acl.grantPermission(_to, _finance, _finance.CREATE_PAYMENTS_ROLE());
+    }
+
+    function _transferCreatePaymentManagerFromTemplate(ACL _acl, Finance _finance, address _manager) internal {
+        _acl.setPermissionManager(_manager, _finance, _finance.CREATE_PAYMENTS_ROLE());
     }
 
     /* TOKEN MANAGER */

--- a/shared/helpers/assertRole.js
+++ b/shared/helpers/assertRole.js
@@ -10,6 +10,13 @@ module.exports = web3 => {
     assert.isTrue(await acl.hasPermission(grantee.address, app.address, permission), `Grantee should have ${appName} role ${roleName}`)
   }
 
+  async function assertRoleNotGranted(acl, app, roleName, to) {
+    const appName = app.constructor.contractName
+    const permission = await app[roleName]()
+
+    assert.isFalse(await acl.hasPermission(to.address, app.address, permission), `Given address should not have ${appName} role ${roleName}`)
+  }
+
   async function assertMissingRole(acl, app, roleName) {
     const appName = app.constructor.contractName
     const permission = await app[roleName]()
@@ -27,6 +34,7 @@ module.exports = web3 => {
 
   return {
     assertRole,
+    assertRoleNotGranted,
     assertMissingRole,
     assertBurnedRole
   }

--- a/shared/truffle.js
+++ b/shared/truffle.js
@@ -1,0 +1,11 @@
+const config = require('@aragon/os/truffle-config')
+
+const gasLimit = 7e6
+
+config.networks.rpc.gas = gasLimit
+config.networks.devnet.gas = gasLimit
+config.networks.rinkeby.gas = gasLimit
+config.networks.ropsten.gas = gasLimit
+config.networks.kovan.gas = gasLimit
+
+module.exports = config

--- a/templates/company-board/README.md
+++ b/templates/company-board/README.md
@@ -80,6 +80,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 
 | App                 | Permission                 | Grantee             | Manager       |
 |---------------------|----------------------------|---------------------|---------------|
+| Finance             | CREATE_PAYMENTS            | Payroll             | Board Voting  |
 | Payroll             | ADD_BONUS_ROLE             | EOA or Board Voting | Board Voting  |
 | Payroll             | ADD_EMPLOYEE_ROLE          | EOA or Board Voting | Board Voting  |
 | Payroll             | ADD_REIMBURSEMENT_ROLE     | EOA or Board Voting | Board Voting  |

--- a/templates/company-board/contracts/CompanyBoardTemplate.sol
+++ b/templates/company-board/contracts/CompanyBoardTemplate.sol
@@ -95,9 +95,10 @@ contract CompanyBoardTemplate is BaseTemplate {
 
         (Kernel dao, Voting shareVoting, Voting boardVoting) = _popDaoCache();
 
-        _setupVaultAndFinanceApps(dao, _financePeriod, _useAgentAsVault, shareVoting, boardVoting);
+        Finance finance = _setupVaultAndFinanceApps(dao, _financePeriod, _useAgentAsVault, shareVoting, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
+        _transferCreatePaymentManagerFromTemplate(ACL(dao.acl()), finance, shareVoting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting);
         _registerID(_id, address(dao));
     }
@@ -134,6 +135,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         _setupPayrollApp(dao, finance, _payrollSettings, boardVoting);
         _finalizeApps(dao, _shareHolders, _shareStakes, _boardMembers, shareVoting, boardVoting);
 
+        _transferCreatePaymentManagerFromTemplate(ACL(dao.acl()), finance, shareVoting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, shareVoting);
         _registerID(_id, address(dao));
     }
@@ -189,6 +191,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         }
         _createVaultPermissions(acl, agentOrVault, finance, _shareVoting);
         _createFinancePermissions(acl, finance, _boardVoting, _shareVoting);
+        _createFinanceCreatePaymentsPermission(acl, finance, _boardVoting, address(this));
 
         return finance;
     }
@@ -200,6 +203,7 @@ contract CompanyBoardTemplate is BaseTemplate {
         Payroll payroll = _installPayrollApp(_dao, _finance, denominationToken, priceFeed, rateExpiryTime);
         ACL acl = ACL(_dao.acl());
         _createPayrollPermissions(acl, payroll, manager, _boardVoting, _boardVoting);
+        _grantCreatePaymentPermission(acl, _finance, payroll);
     }
 
     function _createCustomAgentPermissions(ACL _acl, Agent _agent, Voting _shareVoting, Voting _boardVoting) internal {

--- a/templates/company-board/truffle.js
+++ b/templates/company-board/truffle.js
@@ -1,1 +1,1 @@
-module.exports = require("@aragon/os/truffle-config")
+module.exports = require('@aragon/templates-shared/truffle.js')

--- a/templates/company/README.md
+++ b/templates/company/README.md
@@ -73,6 +73,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 
 | App                 | Permission                 | Grantee             | Manager       |
 |---------------------|----------------------------|---------------------|---------------|
+| Finance             | CREATE_PAYMENTS            | Payroll             | Voting        |
 | Payroll             | ADD_BONUS_ROLE             | EOA or Voting       | Voting        |
 | Payroll             | ADD_EMPLOYEE_ROLE          | EOA or Voting       | Voting        |
 | Payroll             | ADD_REIMBURSEMENT_ROLE     | EOA or Voting       | Voting        |

--- a/templates/company/contracts/CompanyTemplate.sol
+++ b/templates/company/contracts/CompanyTemplate.sol
@@ -85,7 +85,8 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         _ensureCompanySettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
-        (, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
+        (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -118,6 +119,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -152,6 +154,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
 
         Payroll payroll = _installPayrollApp(_dao, _finance, denominationToken, priceFeed, rateExpiryTime);
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
+        _grantCreatePaymentPermission(_acl, _finance, payroll);
     }
 
     function _setupPermissions(
@@ -169,6 +172,7 @@ contract CompanyTemplate is BaseTemplate, TokenCache {
         }
         _createVaultPermissions(_acl, _agentOrVault, _finance, _voting);
         _createFinancePermissions(_acl, _finance, _voting, _voting);
+        _createFinanceCreatePaymentsPermission(_acl, _finance, _voting, address(this));
         _createEvmScriptsRegistryPermissions(_acl, _voting, _voting);
         _createVotingPermissions(_acl, _voting, _voting, _tokenManager, _voting);
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);

--- a/templates/company/truffle.js
+++ b/templates/company/truffle.js
@@ -1,1 +1,1 @@
-module.exports = require("@aragon/os/truffle-config")
+module.exports = require('@aragon/templates-shared/truffle.js')

--- a/templates/membership/README.md
+++ b/templates/membership/README.md
@@ -72,6 +72,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 
 | App                 | Permission                 | Grantee             | Manager       |
 |---------------------|----------------------------|---------------------|---------------|
+| Finance             | CREATE_PAYMENTS            | Payroll             | Voting        |
 | Payroll             | ADD_BONUS_ROLE             | EOA or Voting       | Voting        |
 | Payroll             | ADD_EMPLOYEE_ROLE          | EOA or Voting       | Voting        |
 | Payroll             | ADD_REIMBURSEMENT_ROLE     | EOA or Voting       | Voting        |

--- a/templates/membership/contracts/MembershipTemplate.sol
+++ b/templates/membership/contracts/MembershipTemplate.sol
@@ -80,7 +80,8 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         _ensureMembershipSettings(_members, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
-        (, Voting voting) = _setupApps(dao, acl, _members, _votingSettings, _financePeriod, _useAgentAsVault);
+        (Finance finance, Voting voting) = _setupApps(dao, acl, _members, _votingSettings, _financePeriod, _useAgentAsVault);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -111,6 +112,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _members, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -144,6 +146,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
 
         Payroll payroll = _installPayrollApp(_dao, _finance, denominationToken, priceFeed, rateExpiryTime);
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
+        _grantCreatePaymentPermission(_acl, _finance, payroll);
     }
 
     function _setupPermissions(
@@ -161,6 +164,7 @@ contract MembershipTemplate is BaseTemplate, TokenCache {
         }
         _createVaultPermissions(_acl, _agentOrVault, _finance, _voting);
         _createFinancePermissions(_acl, _finance, _voting, _voting);
+        _createFinanceCreatePaymentsPermission(_acl, _finance, _voting, address(this));
         _createEvmScriptsRegistryPermissions(_acl, _voting, _voting);
         _createVotingPermissions(_acl, _voting, _voting, _tokenManager, _voting);
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);

--- a/templates/membership/test/membership.js
+++ b/templates/membership/test/membership.js
@@ -7,7 +7,7 @@ const { randomId } = require('@aragon/templates-shared/helpers/aragonId')
 const { getEventArgument } = require('@aragon/test-helpers/events')
 const { deployedAddresses } = require('@aragon/templates-shared/lib/arapp-file')(web3)
 const { getInstalledAppsById } = require('@aragon/templates-shared/helpers/events')(artifacts)
-const { assertRole, assertMissingRole } = require('@aragon/templates-shared/helpers/assertRole')(web3)
+const { assertRole, assertMissingRole, assertRoleNotGranted } = require('@aragon/templates-shared/helpers/assertRole')(web3)
 
 const MembershipTemplate = artifacts.require('MembershipTemplate')
 
@@ -151,6 +151,9 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
     it('sets up DAO and ACL permissions correctly', async () => {
       await assertRole(acl, dao, voting, 'APP_MANAGER_ROLE')
       await assertRole(acl, acl, voting, 'CREATE_PERMISSIONS_ROLE')
+
+      await assertRoleNotGranted(acl, dao, 'APP_MANAGER_ROLE', template)
+      await assertRoleNotGranted(acl, acl, 'CREATE_PERMISSIONS_ROLE', template)
     })
 
     it('sets up EVM scripts registry permissions correctly', async () => {
@@ -198,13 +201,16 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
       assert.equal(await payroll.denominationToken(), PAYROLL_DENOMINATION_TOKEN)
       assert.equal(web3.toChecksumAddress(await payroll.finance()), finance.address)
 
-      const expectedManager = employeeManager === ZERO_ADDRESS ? voting : { address: employeeManager }
+      await assertRole(acl, finance, voting, 'CREATE_PAYMENTS_ROLE', payroll)
+      await assertRoleNotGranted(acl, finance, 'CREATE_PAYMENTS_ROLE', template)
 
-      await assertRole(acl, payroll, voting, 'ADD_BONUS_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'ADD_EMPLOYEE_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'ADD_REIMBURSEMENT_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'TERMINATE_EMPLOYEE_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'SET_EMPLOYEE_SALARY_ROLE', expectedManager)
+      const expectedGrantee = employeeManager === ZERO_ADDRESS ? voting : { address: employeeManager }
+
+      await assertRole(acl, payroll, voting, 'ADD_BONUS_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'ADD_EMPLOYEE_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'ADD_REIMBURSEMENT_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'TERMINATE_EMPLOYEE_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'SET_EMPLOYEE_SALARY_ROLE', expectedGrantee)
 
       await assertRole(acl, payroll, voting, 'MODIFY_PRICE_FEED_ROLE', voting)
       await assertRole(acl, payroll, voting, 'MODIFY_RATE_EXPIRY_ROLE', voting)
@@ -250,7 +256,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const USE_AGENT_AS_VAULT = true
 
           createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-          itCostsUpTo(6.71e6)
+          itCostsUpTo(6.75e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
         })
@@ -272,7 +278,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const USE_AGENT_AS_VAULT = true
 
           createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-          itCostsUpTo(6.71e6)
+          itCostsUpTo(6.75e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
         })
@@ -352,7 +358,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
             const USE_AGENT_AS_VAULT = true
 
             createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-            itCostsUpTo(5e6)
+            itCostsUpTo(5.05e6)
             itSetupsDAOCorrectly(FINANCE_PERIOD)
             itSetupsAgentAppCorrectly()
           })
@@ -374,7 +380,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
             const USE_AGENT_AS_VAULT = true
 
             createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-            itCostsUpTo(5e6)
+            itCostsUpTo(5.05e6)
             itSetupsDAOCorrectly(FINANCE_PERIOD)
             itSetupsAgentAppCorrectly()
           })
@@ -410,7 +416,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const EMPLOYEE_MANAGER = someone
 
           createDAO(EMPLOYEE_MANAGER)
-          itCostsUpTo(6.2e6)
+          itCostsUpTo(6.23e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
           itSetupsPayrollAppCorrectly(EMPLOYEE_MANAGER)
@@ -420,7 +426,7 @@ contract('Membership', ([_, owner, member1, member2, someone]) => {
           const EMPLOYEE_MANAGER = ZERO_ADDRESS
 
           createDAO(EMPLOYEE_MANAGER)
-          itCostsUpTo(6.2e6)
+          itCostsUpTo(6.23e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
           itSetupsPayrollAppCorrectly(EMPLOYEE_MANAGER)

--- a/templates/membership/truffle.js
+++ b/templates/membership/truffle.js
@@ -1,1 +1,1 @@
-module.exports = require("@aragon/os/truffle-config")
+module.exports = require('@aragon/templates-shared/truffle.js')

--- a/templates/reputation/README.md
+++ b/templates/reputation/README.md
@@ -73,6 +73,7 @@ The network details will be automatically selected by the `arapp.json`'s environ
 
 | App                 | Permission                 | Grantee             | Manager       |
 |---------------------|----------------------------|---------------------|---------------|
+| Finance             | CREATE_PAYMENTS            | Payroll             | Voting        |
 | Payroll             | ADD_BONUS_ROLE             | EOA or Voting       | Voting        |
 | Payroll             | ADD_EMPLOYEE_ROLE          | EOA or Voting       | Voting        |
 | Payroll             | ADD_REIMBURSEMENT_ROLE     | EOA or Voting       | Voting        |

--- a/templates/reputation/contracts/ReputationTemplate.sol
+++ b/templates/reputation/contracts/ReputationTemplate.sol
@@ -85,7 +85,8 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         _ensureReputationSettings(_holders, _stakes, _votingSettings);
 
         (Kernel dao, ACL acl) = _createDAO();
-        (, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
+        (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -118,6 +119,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         (Kernel dao, ACL acl) = _createDAO();
         (Finance finance, Voting voting) = _setupApps(dao, acl, _holders, _stakes, _votingSettings, _financePeriod, _useAgentAsVault);
         _setupPayrollApp(dao, acl, finance, voting, _payrollSettings);
+        _transferCreatePaymentManagerFromTemplate(acl, finance, voting);
         _transferRootPermissionsFromTemplateAndFinalizeDAO(dao, voting);
         _registerID(_id, dao);
     }
@@ -152,6 +154,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
 
         Payroll payroll = _installPayrollApp(_dao, _finance, denominationToken, priceFeed, rateExpiryTime);
         _createPayrollPermissions(_acl, payroll, manager, _voting, _voting);
+        _grantCreatePaymentPermission(_acl, _finance, payroll);
     }
 
     function _setupPermissions(
@@ -169,6 +172,7 @@ contract ReputationTemplate is BaseTemplate, TokenCache {
         }
         _createVaultPermissions(_acl, _agentOrVault, _finance, _voting);
         _createFinancePermissions(_acl, _finance, _voting, _voting);
+        _createFinanceCreatePaymentsPermission(_acl, _finance, _voting, address(this));
         _createEvmScriptsRegistryPermissions(_acl, _voting, _voting);
         _createVotingPermissions(_acl, _voting, _voting, _tokenManager, _voting);
         _createTokenManagerPermissions(_acl, _tokenManager, _voting, _voting);

--- a/templates/reputation/test/reputation.js
+++ b/templates/reputation/test/reputation.js
@@ -7,7 +7,7 @@ const { randomId } = require('@aragon/templates-shared/helpers/aragonId')
 const { getEventArgument } = require('@aragon/test-helpers/events')
 const { deployedAddresses } = require('@aragon/templates-shared/lib/arapp-file')(web3)
 const { getInstalledAppsById } = require('@aragon/templates-shared/helpers/events')(artifacts)
-const { assertRole, assertMissingRole } = require('@aragon/templates-shared/helpers/assertRole')(web3)
+const { assertRole, assertMissingRole, assertRoleNotGranted } = require('@aragon/templates-shared/helpers/assertRole')(web3)
 
 const ReputationTemplate = artifacts.require('ReputationTemplate')
 
@@ -152,6 +152,9 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
     it('sets up DAO and ACL permissions correctly', async () => {
       await assertRole(acl, dao, voting, 'APP_MANAGER_ROLE')
       await assertRole(acl, acl, voting, 'CREATE_PERMISSIONS_ROLE')
+
+      await assertRoleNotGranted(acl, dao, 'APP_MANAGER_ROLE', template)
+      await assertRoleNotGranted(acl, acl, 'CREATE_PERMISSIONS_ROLE', template)
     })
 
     it('sets up EVM scripts registry permissions correctly', async () => {
@@ -199,13 +202,16 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
       assert.equal(await payroll.denominationToken(), PAYROLL_DENOMINATION_TOKEN)
       assert.equal(web3.toChecksumAddress(await payroll.finance()), finance.address)
 
-      const expectedManager = employeeManager === ZERO_ADDRESS ? voting : { address: employeeManager }
+      await assertRole(acl, finance, voting, 'CREATE_PAYMENTS_ROLE', payroll)
+      await assertRoleNotGranted(acl, finance, 'CREATE_PAYMENTS_ROLE', template)
 
-      await assertRole(acl, payroll, voting, 'ADD_BONUS_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'ADD_EMPLOYEE_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'ADD_REIMBURSEMENT_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'TERMINATE_EMPLOYEE_ROLE', expectedManager)
-      await assertRole(acl, payroll, voting, 'SET_EMPLOYEE_SALARY_ROLE', expectedManager)
+      const expectedGrantee = employeeManager === ZERO_ADDRESS ? voting : { address: employeeManager }
+
+      await assertRole(acl, payroll, voting, 'ADD_BONUS_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'ADD_EMPLOYEE_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'ADD_REIMBURSEMENT_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'TERMINATE_EMPLOYEE_ROLE', expectedGrantee)
+      await assertRole(acl, payroll, voting, 'SET_EMPLOYEE_SALARY_ROLE', expectedGrantee)
 
       await assertRole(acl, payroll, voting, 'MODIFY_PRICE_FEED_ROLE', voting)
       await assertRole(acl, payroll, voting, 'MODIFY_RATE_EXPIRY_ROLE', voting)
@@ -363,7 +369,7 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
             const USE_AGENT_AS_VAULT = true
 
             createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-            itCostsUpTo(5e6)
+            itCostsUpTo(5.05e6)
             itSetupsDAOCorrectly(FINANCE_PERIOD)
             itSetupsAgentAppCorrectly()
           })
@@ -385,7 +391,7 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
             const USE_AGENT_AS_VAULT = true
 
             createDAO(USE_AGENT_AS_VAULT, FINANCE_PERIOD)
-            itCostsUpTo(5e6)
+            itCostsUpTo(5.05e6)
             itSetupsDAOCorrectly(FINANCE_PERIOD)
             itSetupsAgentAppCorrectly()
           })
@@ -421,7 +427,7 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
           const EMPLOYEE_MANAGER = someone
 
           createDAO(EMPLOYEE_MANAGER)
-          itCostsUpTo(6.2e6)
+          itCostsUpTo(6.23e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
           itSetupsPayrollAppCorrectly(EMPLOYEE_MANAGER)
@@ -431,7 +437,7 @@ contract('Reputation', ([_, owner, holder1, holder2, someone]) => {
           const EMPLOYEE_MANAGER = ZERO_ADDRESS
 
           createDAO(EMPLOYEE_MANAGER)
-          itCostsUpTo(6.2e6)
+          itCostsUpTo(6.23e6)
           itSetupsDAOCorrectly(FINANCE_PERIOD)
           itSetupsAgentAppCorrectly()
           itSetupsPayrollAppCorrectly(EMPLOYEE_MANAGER)

--- a/templates/reputation/truffle.js
+++ b/templates/reputation/truffle.js
@@ -1,1 +1,1 @@
-module.exports = require("@aragon/os/truffle-config")
+module.exports = require('@aragon/templates-shared/truffle.js')

--- a/templates/trust/contracts/TrustTemplate.sol
+++ b/templates/trust/contracts/TrustTemplate.sol
@@ -140,6 +140,7 @@ contract TrustTemplate is BaseTemplate {
         // Set up permissions
         _createVaultPermissions(acl, vault, finance, holdVoting);
         _createFinancePermissions(acl, finance, holdVoting, holdVoting);
+        _createFinanceCreatePaymentsPermission(acl, finance, holdVoting, holdVoting);
         _createEvmScriptsRegistryPermissions(acl, holdVoting, holdVoting);
         _createCustomAgentPermissions(acl, agent, holdVoting, heirsVoting);
         _createCustomVotingPermissions(acl, holdTokenManager, holdVoting);

--- a/templates/trust/truffle.js
+++ b/templates/trust/truffle.js
@@ -1,1 +1,1 @@
-module.exports = require("@aragon/os/truffle-config")
+module.exports = require('@aragon/templates-shared/truffle.js')


### PR DESCRIPTION
#### ⚠️ Caveat
- The pattern to avoid doing a huge refactor and avoid `stack too deep` issues was to define the Finance app `CREATE_PAYMENTS_ROLE` permission manager at the end of the setup right before transferring `APP_MANAGER_ROLE` and `CREATE_PERMISSIONS_ROLE` for both cases: single and separate transactions (see https://github.com/aragon/dao-templates/pull/151/files#diff-52f12760537c9db9be3fa686835f7701R120). As you may have noticed, this means a little waste of gas for the scenarios where we don't request a Payroll app to be installed, but as mentioned above, it was the smoothest way to avoid a huge refactor and `stack too deep` issues.

- I needed to increase the gas limit a bit (from 6.9e6 to 7e6) to make the single-tx cases with agent app pass (https://github.com/aragon/dao-templates/compare/grant_create_payments_permission_to_payroll?expand=1#diff-5f384e61558bd769cae90a4171daa061R3)

#### Problem
Employees will not be able to get their salary as Payroll does not have permissions on Finance to create payments. This permission is needed in order to pay out employee salaries when an employee calls `Payroll.payday()`.

#### Solution
Grant `CREATE_PAYMENT` permission on Finance for Payroll. Note even though Payroll allows employees to call `evmScript`s, interaction with Finance via `forward()` is blacklisted.

#### Audit issue
https://github.com/aragonone/aragon-daotemplates-audit-report-2019-08#65-payroll-is-missing-permissions-to-create-payments-on-finance