### PR TITLE
Add truffle to the publish files

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -10,6 +10,7 @@
     "helpers/",
     "lib/",
     "scripts/",
+    "truffle.js",
     "docker-compose.yml"
   ],
   "scripts": {


### PR DESCRIPTION
Fixes #163 

This was not a problem with the core templates because the `template-shared` dependency is linked by `lerna bootstrap`

TODO:

- [ ] Release a patch of `@aragon/templates-shared`